### PR TITLE
[CHORE] - Add astro-galaxy-core dependency to components

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -10,12 +10,14 @@
     "lib"
   ],
   "dependencies": {
+    "@magnetis/astro-galaxy-core": "1.0.0-alpha.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "styled-components": "^4.3.2",
     "styled-system": "^5.0.12"
   },
   "peerDependencies": {
+    "@magnetis/astro-galaxy-core": "1.0.0-alpha.1",
     "react": "^15.0.0 || ^16.0.0",
     "react-dom": "^15.0.0 || ^16.0.0",
     "styled-components": "^4.0.0",


### PR DESCRIPTION
# What

We are missing `@magnetis/astro-galaxy-core` inside `packages/components`.

# Why

We gonna need some tools that are provided by `@magnetis/astro-galaxy-core`.
