### PR TITLE
Add initial iconography page

### DIFF
--- a/packages/docs/src/components/icons-collection.js
+++ b/packages/docs/src/components/icons-collection.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import styled from 'styled-components';
+import map from 'lodash/map';
+import * as icons from '@magnetis/astro-galaxy-icons';
+
+const Collection = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  margin-left: -16px;
+`;
+
+const Item = styled.div`
+  margin: 16px;
+  text-align: center;
+  width: 72px;
+`;
+
+const Container = styled.div`
+  border: solid 1px silver;
+  border-radius: 8px;
+  padding: 16px;
+`;
+
+const Name = styled.div`
+  font-family: 'Poppins', Arial, Helvetica, sans-serif;
+  font-size: 10px;
+  margin-top: 8px;
+`;
+
+const IconsCollection = () => (
+  <Collection>
+    {icons &&
+      map(icons, (Icon, IconName) => (
+        <Item>
+          <Container>
+            <Icon key={IconName} color="moon900" width="32" height="32" />
+          </Container>
+          <Name>{IconName.replace('Icon', '')}</Name>
+        </Item>
+      ))}
+  </Collection>
+);
+
+export default IconsCollection;

--- a/packages/docs/src/pages/iconography.mdx
+++ b/packages/docs/src/pages/iconography.mdx
@@ -1,0 +1,13 @@
+---
+name: iconography
+---
+
+import IconsCollection from '../components/icons-collection';
+
+# iconography
+
+#### Icons carry affordance and interaction patterns of Magnetis’ platform. They should be used in meaningful assets like buttons and visual informative support to help users navigate through our product.
+
+All icons have a 32x32px bound as default format. They can be resized in our 16px baseline as required.
+
+<IconsCollection />


### PR DESCRIPTION
# What

This PR adds an initial and simple version of the iconography page.

# Why

To display Astro Galaxy icons.

# How

* Add a simple icon list component
* Add an initial iconography page

# Sample

<img width="1434" alt="Captura de Tela 2019-12-12 às 16 43 41" src="https://user-images.githubusercontent.com/1002072/70743474-9a0c7500-1cfe-11ea-9c41-57386d45fc88.png">

_PS. This page was created without text styles (typography styles lives in another PR)._
