### PR TITLE
Update typography page copy and change header color

### DIFF
--- a/packages/docs/src/components/Layout.js
+++ b/packages/docs/src/components/Layout.js
@@ -13,7 +13,7 @@ const Page = styled.div`
 `;
 
 const ContentWrapper = styled.div`
-  background-image: ${props => props.theme.gradients.nebulosa};
+  background-image: ${props => props.theme.gradients.blackhole};
   background-size: 100% 312px;
   background-position: center top;
   background-repeat: no-repeat;
@@ -33,11 +33,27 @@ const Content = styled.div`
     width: 90%;
   }
 
+  & h2,
+  h3 {
+    color: ${props => props.theme.colors.moon500};
+  }
+
+  h2 {
+    font-size: ${props => props.theme.fontSizes.texts.large};
+  }
+
+  h3 {
+    font-size: ${props => props.theme.fontSizes.texts.medium};
+    margin-top: ${props => props.theme.space[4]}px;
+  }
+
   & code {
     background-color: ${props => props.theme.colors.space200};
     color: ${props => props.theme.colors.moon400};
     font-family: monospace;
-    font-size: ${props => props.theme.fontSizes.texts.small};
+    font-size: 0.8em;
+    padding: 2px 5px;
+    margin: 0 3px;
   }
 `;
 

--- a/packages/docs/src/pages/buttons.mdx
+++ b/packages/docs/src/pages/buttons.mdx
@@ -21,7 +21,7 @@ import PropsTableWrapper from '../components/PropsTable';
   background or foreground of an experience.
 </Text>
 
-<Text as="h2" fontSize="large" color="moon500">
+<Text as="h2">
   primary buttons
 </Text>
 
@@ -54,7 +54,7 @@ Mouseover and click to view `:hover` and `:active` states.
   `}
 />
 
-<Text as="h3" fontSize="medium" color="moon500">
+<Text as="h3">
   sizes
 </Text>
 
@@ -73,7 +73,7 @@ Mouseover and click to view `:hover` and `:active` states.
   `}
 />
 
-<Text as="h3" fontSize="medium" color="moon500">
+<Text as="h3">
   props
 </Text>
 
@@ -136,7 +136,7 @@ Mouseover and click to view `:hover` and `:active` states.
   </table>
 </PropsTableWrapper>
 
-<Text as="h2" fontSize="large" color="moon500">
+<Text as="h2">
   outline buttons
 </Text>
 
@@ -169,7 +169,7 @@ Mouseover and click to view `:hover` and `:active` states.
   `}
 />
 
-<Text as="h3" fontSize="medium" color="moon500">
+<Text as="h3">
   sizes
 </Text>
 
@@ -188,7 +188,7 @@ Mouseover and click to view `:hover` and `:active` states.
   `}
 />
 
-<Text as="h3" fontSize="medium" color="moon500">
+<Text as="h3">
   props
 </Text>
 
@@ -251,7 +251,7 @@ Mouseover and click to view `:hover` and `:active` states.
   </table>
 </PropsTableWrapper>
 
-<Text as="h2" fontSize="large" color="moon500">
+<Text as="h2">
   icon buttons
 </Text>
 
@@ -284,7 +284,7 @@ Mouseover and click to view `:hover` and `:active` states.
   `}
 />
 
-<Text as="h3" fontSize="medium" color="moon500">
+<Text as="h3">
   sizes
 </Text>
 
@@ -303,13 +303,13 @@ Mouseover and click to view `:hover` and `:active` states.
   `}
 />
 
-<Text as="h3" fontSize="medium" color="moon500">
+<Text as="h3">
   props
 </Text>
 
 Refer to iconlabel buttons below.
 
-<Text as="h2" fontSize="large" color="moon500">
+<Text as="h2">
   iconlabel buttons
 </Text>
 
@@ -341,7 +341,7 @@ Mouseover and click to view `:hover` and `:active` states.
   `}
 />
 
-<Text as="h3" fontSize="medium" color="moon500">
+<Text as="h3">
   sizes
 </Text>
 
@@ -363,7 +363,7 @@ Mouseover and click to view `:hover` and `:active` states.
   `}
 />
 
-<Text as="h3" fontSize="medium" color="moon500">
+<Text as="h3">
   props
 </Text>
 
@@ -444,7 +444,7 @@ Mouseover and click to view `:hover` and `:active` states.
   </table>
 </PropsTableWrapper>
 
-<Text as="h2" fontSize="large" color="moon500">
+<Text as="h2">
   icon outline buttons
 </Text>
 
@@ -477,7 +477,7 @@ Mouseover and click to view `:hover` and `:active` states.
   `}
 />
 
-<Text as="h3" fontSize="medium" color="moon500">
+<Text as="h3">
   sizes
 </Text>
 
@@ -496,13 +496,13 @@ Mouseover and click to view `:hover` and `:active` states.
   `}
 />
 
-<Text as="h3" fontSize="medium" color="moon500">
+<Text as="h3">
   props
 </Text>
 
 Refer to iconlabel outline buttons buttons below.
 
-<Text as="h2" fontSize="large" color="moon500">
+<Text as="h2">
   iconlabel outline buttons
 </Text>
 
@@ -534,7 +534,7 @@ Mouseover and click to view `:hover` and `:active` states.
   `}
 />
 
-<Text as="h3" fontSize="medium" color="moon500">
+<Text as="h3">
   sizes
 </Text>
 
@@ -556,7 +556,7 @@ Mouseover and click to view `:hover` and `:active` states.
   `}
 />
 
-<Text as="h3" fontSize="medium" color="moon500">
+<Text as="h3">
   props
 </Text>
 
@@ -637,7 +637,7 @@ Mouseover and click to view `:hover` and `:active` states.
   </table>
 </PropsTableWrapper>
 
-<Text as="h2" fontSize="large" color="moon500">
+<Text as="h2">
   ghost icon buttons
 </Text>
 
@@ -670,7 +670,7 @@ Mouseover and click to view `:hover` and `:active` states.
   `}
 />
 
-<Text as="h3" fontSize="medium" color="moon500">
+<Text as="h3">
   sizes
 </Text>
 
@@ -689,13 +689,13 @@ Mouseover and click to view `:hover` and `:active` states.
   `}
 />
 
-<Text as="h3" fontSize="medium" color="moon500">
+<Text as="h3">
   props
 </Text>
 
 Refer to ghost iconlabel buttons below.
 
-<Text as="h2" fontSize="large" color="moon500">
+<Text as="h2">
   ghost iconlabel buttons
 </Text>
 
@@ -735,7 +735,7 @@ Mouseover and click to view `:hover` and `:active` states.
   `}
 />
 
-<Text as="h3" fontSize="medium" color="moon500">
+<Text as="h3">
   sizes
 </Text>
 
@@ -757,7 +757,7 @@ Mouseover and click to view `:hover` and `:active` states.
   `}
 />
 
-<Text as="h3" fontSize="medium" color="moon500">
+<Text as="h3">
   props
 </Text>
 

--- a/packages/docs/src/pages/typography.mdx
+++ b/packages/docs/src/pages/typography.mdx
@@ -3,60 +3,65 @@ title: typography
 ---
 
 import Playground from '../components/Playground';
+import PropsTableWrapper from '../components/PropsTable';
 import { Text, Heading } from '@magnetis/astro-galaxy-components';
 
-# typography
+<Text font="secondary" fontSize="large" color="moon400" marginBottom={5}>
+  Astro has a purposeful set of typographic styles that provide content organization, hierarchy
+  patterns and consistent information architecture which is essential for good understanding and a
+  solid user experience.
+</Text>
 
-#### Astro has a purposeful set of typographic styles that provide content organization, hierarchy patterns and consistent information architecture which is essential for good understanding and a solid user experience.
+There are two types of typography components: `Heading` and `Text`. You should modify the component tag for semantic purposes with the prop `as`, passing a tag like `"h1"` for example. We advise to keep style and semantics independent, so you can modify the size regardless of the tag - see all size variations under "sizes" below.
 
-## poppins
+<Text as="h2">poppins</Text>
 
 Poppins is our primary font, used in the whole product’s interfaces for interactive components, contextual titles and texts. Poppins provides good legibility in small and large sizes.
 
-<Playground 
+<Playground
   scope={{ Text }}
-  code={
-  `
+  code={`
   <Text fontSize="large">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z</Text>
   <Text fontSize="large">a b c d e f g h i j k l m n o p q r s t u v w x y z</Text>
   <Text fontSize="large">0 1 2 3 4 5 6 7 8 9</Text>
   `}
 />
 
+To use a text component with Poppins, use the prop `font` with the value `primary`. You can also modify the color with the prop `color`.
 
-<Playground 
+<Text as="h3">sizes</Text>
+
+To modify font size for both `Heading` or `Text` components, use the prop `fontSize` with the values `small`, `medium` or `large`. Default size is `medium`. See prop details on the table below.
+
+<Playground scope={{ Heading }} code={`<Heading fontSize="huge">display. huge</Heading>`} />
+
+<Playground
   scope={{ Heading }}
-  code={
-  `<Heading fontSize="huge">display. huge</Heading>`}/>
-
-
-
-<Playground 
-  scope={{ Heading }}
-  code={
-  `<Heading fontSize="large">title. large</Heading>
+  code={`<Heading fontSize="large">title. large</Heading>
   <Heading fontSize="medium">title. medium</Heading>
-  <Heading fontSize="small">title. small</Heading>`}/>
+  <Heading fontSize="small">title. small</Heading>`}
+/>
 
-
-
-<Playground 
+<Playground
   scope={{ Text }}
-  code={
-  `<Text fontSize="large">text. large</Text>
+  code={`<Text fontSize="large">text. large</Text>
   <Text fontSize="medium">text. medium</Text>
   <Text fontSize="small">text. small</Text>
   <Text fontSize="verySmall">text. very small</Text>
-`}/>
+`}
+/>
 
-## lato
+<Text as="h3">props</Text>
+
+See the universal props table in the bottom of this page.
+
+<Text as="h2">lato</Text>
 
 Lato is our secondary font. Used in informative texts and components that demand smaller labels, Lato provides good and dynamic legibility, with a serious but friendly structure.
 
-<Playground 
+<Playground
   scope={{ Text }}
-  code={
-  `<Text fontSize="large" font="secondary">
+  code={`<Text fontSize="large" font="secondary">
     A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
   </Text>
   <Text fontSize="large" font="secondary">
@@ -65,14 +70,18 @@ Lato is our secondary font. Used in informative texts and components that demand
   <Text fontSize="large" font="secondary">
     0 1 2 3 4 5 6 7 8 9
   </Text>
-`}/>
+`}
+/>
 
-### sizes
+To use a text component with Lato, use the prop `font` with the value `secondary`. You can also modify the color with the prop `color`.
 
-<Playground 
+<Text as="h3">sizes</Text>
+
+To modify font size for both `Heading` or `Text` components, use the prop `fontSize` with the values `small`, `medium` or `large`. Default size is `medium`. See prop details on the table below.
+
+<Playground
   scope={{ Text }}
-  code={
-  `<Text fontSize="large" font="secondary">
+  code={`<Text fontSize="large" font="secondary">
     text. large
   </Text>
   <Text fontSize="medium" font="secondary">
@@ -84,4 +93,66 @@ Lato is our secondary font. Used in informative texts and components that demand
   <Text fontSize="verySmall" font="secondary">
     text. very small
   </Text>
-`}/>
+`}
+/>
+
+<Text as="h3">props</Text>
+
+<PropsTableWrapper>
+  <table>
+    <thead>
+      <tr>
+        <th>property</th>
+        <th>PropType</th>
+        <th>required</th>
+        <th>default</th>
+        <th>description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>children</td>
+        <td>node</td>
+        <td>no</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>as</td>
+        <td>string</td>
+        <td>no</td>
+        <td></td>
+        <td>Change component's tag.</td>
+      </tr>
+      <tr>
+        <td>font</td>
+        <td>string</td>
+        <td>no</td>
+        <td>
+          <code>primary</code>
+        </td>
+        <td>
+          Change font variant. "primary" is Poppins and "secondary" is Lato.
+        </td>
+      </tr>
+      <tr>
+        <td>fontSize</td>
+        <td>string</td>
+        <td>no</td>
+        <td>
+          <code>medium</code>
+        </td>
+        <td>Change font size. "small", "medium", "large".</td>
+      </tr>
+      <tr>
+        <td>color</td>
+        <td>string</td>
+        <td>no</td>
+        <td>
+          <code>moon900</code>
+        </td>
+        <td>Change font color. Use any Astro color variable.</td>
+      </tr>
+    </tbody>
+  </table>
+</PropsTableWrapper>


### PR DESCRIPTION
# What

Update Typography page copywriting in the documentation;
Change header color to `blackhole`.

# Why

This is an improvement to explain usage of our text components.
The header color change was decided to differentiate the main Astro website from the Astro Galaxy.
