### PR TITLE
Add docs about buttons in `<a>` elements

### DIFF
--- a/packages/components/src/Button/index.js
+++ b/packages/components/src/Button/index.js
@@ -49,19 +49,20 @@ const Button = styled.button`
   border-width: 2px;
   border-style: solid;
 
-  :disabled {
+  :disabled,
+  .disabled {
     cursor: not-allowed;
     background-color: ${props => props.theme.colors.moon200};
     border-color: ${props => props.theme.colors.moon200};
     color: ${props => props.theme.colors.space100};
   }
 
-  :hover:not(:disabled),
-  :focus:not(:disabled) {
+  :hover:not(:disabled):not(.disabled),
+  :focus:not(:disabled):not(.disabled) {
     ${props => hoverStyles(props)[props.variant]}
   }
 
-  :active:not(:disabled) {
+  :active:not(:disabled):not(.disabled) {
     ${props => activeStyles(props)[props.variant]}
   }
 

--- a/packages/components/src/Button/index.js
+++ b/packages/components/src/Button/index.js
@@ -49,20 +49,19 @@ const Button = styled.button`
   border-width: 2px;
   border-style: solid;
 
-  :disabled,
-  .disabled {
+  :disabled {
     cursor: not-allowed;
     background-color: ${props => props.theme.colors.moon200};
     border-color: ${props => props.theme.colors.moon200};
     color: ${props => props.theme.colors.space100};
   }
 
-  :hover:not(:disabled):not(.disabled),
-  :focus:not(:disabled):not(.disabled) {
+  :hover:not(:disabled),
+  :focus:not(:disabled) {
     ${props => hoverStyles(props)[props.variant]}
   }
 
-  :active:not(:disabled):not(.disabled) {
+  :active:not(:disabled) {
     ${props => activeStyles(props)[props.variant]}
   }
 

--- a/packages/docs/src/pages/buttons.mdx
+++ b/packages/docs/src/pages/buttons.mdx
@@ -900,3 +900,23 @@ Mouseover and click to view `:hover` and `:active` states.
     </tbody>
   </table>
 </PropsTableWrapper>
+
+## buttons in `<a>` elements
+
+Although our button components are `<button>` elements by default, you may also use them as `<a>` elements when semantically recommended by passing the prop `as="a"`. Note that some browsers may render them slightly differently.
+
+`<a>` elements don't have a `:disabled` attribute/pseudo selector, so if you need such state, you'll have to add the `disabled` class like the example below.
+
+If your `<a>` button triggers in-page functionalities instead of linking (to other pages or within the current page), make them semantically accessible by adding a `role="button"`.
+
+<Playground
+  scope={{ Button }}
+  code={`
+    <Button as="a" variant="primary.uranus">
+      link button
+    </Button>
+    <Button as="a" className="disabled">
+      disabled
+    </Button>
+  `}
+/>

--- a/packages/docs/src/pages/buttons.mdx
+++ b/packages/docs/src/pages/buttons.mdx
@@ -859,7 +859,10 @@ Mouseover and click to view `:hover` and `:active` states.
         <td>
           <code>medium</code>
         </td>
-        <td>Change button size. "small", "medium", "large". Although supported, small and large are not on our official collection for this button.</td>
+        <td>
+          Change button size. "small", "medium", "large". Although supported, small and large are
+          not on our official collection for this button.
+        </td>
       </tr>
       <tr>
         <td>disabled</td>
@@ -905,8 +908,6 @@ Mouseover and click to view `:hover` and `:active` states.
 
 Although our button components are `<button>` elements by default, you may also use them as `<a>` elements when semantically recommended by passing the prop `as="a"`. Note that some browsers may render them slightly differently.
 
-`<a>` elements don't have a `:disabled` attribute/pseudo selector, so if you need such state, you'll have to add the `disabled` class like the example below.
-
 If your `<a>` button triggers in-page functionalities instead of linking (to other pages or within the current page), make them semantically accessible by adding a `role="button"`.
 
 <Playground
@@ -914,9 +915,6 @@ If your `<a>` button triggers in-page functionalities instead of linking (to oth
   code={`
     <Button as="a" variant="primary.uranus">
       link button
-    </Button>
-    <Button as="a" className="disabled">
-      disabled
     </Button>
   `}
 />


### PR DESCRIPTION
# What

Add a disclaimer about buttons in `<a>` elements usage in the buttons page.

