### PR TITLE
General quick improvements

### DIFF
--- a/packages/components/src/Heading/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/components/src/Heading/__tests__/__snapshots__/index.test.js.snap
@@ -2,8 +2,6 @@
 
 exports[`Heading renders correctly 1`] = `
 .c0 {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
   color: #32383c;
   font-size: large;
   font: normal normal 600 normal 16px/1.5 Poppins,sans-serif;

--- a/packages/components/src/Heading/index.js
+++ b/packages/components/src/Heading/index.js
@@ -2,8 +2,6 @@ import styled from 'styled-components';
 import { color, space, layout, typography } from 'styled-system';
 
 const Heading = styled.h1`
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
   ${color}
   ${space}
   ${layout}

--- a/packages/components/src/IconButton/index.js
+++ b/packages/components/src/IconButton/index.js
@@ -44,7 +44,7 @@ const buttonPadding = () => ({
   `,
 });
 
-const iconlabelMargin = props => {
+export const iconlabelMargin = props => {
   if (props.iconlabel && !props.iconlabelRight) {
     return '-4px 9px -3px 0';
   }

--- a/packages/components/src/IconLinkButton/index.js
+++ b/packages/components/src/IconLinkButton/index.js
@@ -2,18 +2,7 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { color, space, border, layout, fontSize, typography } from 'styled-system';
 import { font, buttonSizes } from '@magnetis/astro-galaxy-core';
-
-const iconlabelMargin = props => {
-  if (props.iconlabel && !props.iconlabelRight) {
-    return '-4px 9px -3px 0';
-  }
-
-  if (props.iconlabel && props.iconlabelRight) {
-    return '-4px 0 -3px 9px';
-  }
-
-  return '-4px 0 -3px';
-};
+import { iconlabelMargin } from '../IconButton';
 
 const IconLinkButton = styled.button`
   ${font};

--- a/packages/components/src/Text/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/components/src/Text/__tests__/__snapshots__/index.test.js.snap
@@ -2,8 +2,6 @@
 
 exports[`Text renders correctly 1`] = `
 .c0 {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
   color: #32383c;
   font-size: medium;
   font: normal normal 600 normal 16px/1.5 Poppins,sans-serif;

--- a/packages/components/src/Text/index.js
+++ b/packages/components/src/Text/index.js
@@ -3,8 +3,6 @@ import { color, space, layout, typography } from 'styled-system';
 import { font } from '@magnetis/astro-galaxy-core';
 
 const Text = styled.p`
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
   ${color}
   ${space}
   ${layout}

--- a/packages/core/src/theme-provider/index.js
+++ b/packages/core/src/theme-provider/index.js
@@ -98,6 +98,11 @@ const GlobalStyle = createGlobalStyle`
   *, :after, :before {
     box-sizing: border-box;
   }
+  
+  * {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
 `;
 
 export default props => (

--- a/packages/docs/src/components/Layout.js
+++ b/packages/docs/src/components/Layout.js
@@ -7,11 +7,14 @@ import breakpoints from '../utils/breakpoints';
 import Sidebar from './Sidebar';
 
 const Page = styled.div`
-  display: flex;
   font: ${props => props.theme.fonts.secondary};
   color: ${props => props.theme.colors.moon900};
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  ${breakpoints.min('md')} {
+    display: flex;
+  }
 `;
 
 const ContentWrapper = styled.div`

--- a/packages/docs/src/components/Playground.js
+++ b/packages/docs/src/components/Playground.js
@@ -13,6 +13,7 @@ const Wrapper = styled.div`
 const PreviewWrapper = styled.div`
   padding: 25px 15px;
   border-bottom: 1px solid ${props => props.theme.colors.space400};
+  overflow-x: scroll;
 
   & > div {
     margin: -8px;
@@ -24,7 +25,7 @@ const PreviewWrapper = styled.div`
 `;
 
 const EditorWrapper = styled.div`
-  background: ${props => props.theme.colors.space200};
+  background: ${props => props.theme.colors.moon900};
   padding: 15px 5px !important;
   display: ${props => (props.visible ? 'block' : 'none')};
 

--- a/packages/docs/src/components/PropsTable.js
+++ b/packages/docs/src/components/PropsTable.js
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 
 const PropsTableWrapper = styled.div`
   margin-bottom: 32px;
+  width: 100%;
+  overflow-x: auto;
 
   & table {
     border-collapse: collapse;

--- a/packages/docs/src/pages/buttons.mdx
+++ b/packages/docs/src/pages/buttons.mdx
@@ -602,9 +602,9 @@ Mouseover and click to view `:hover` and `:active` states.
   </table>
 </PropsTableWrapper>
 
-## ghost icon buttons
+## icon ghost buttons
 
-Ghost icon buttons can be used for simple microinteractions and commands.
+Icon Ghost buttons can be used for simple microinteractions and commands.
 
 To create an ghost icon button import `IconGhostButton` component and use `variant` prop with `ghost.uranus` value. Then, add an icon component inside the icon button. See our <Link to="/iconography">Iconography</Link> to learn how to use Astro icons.
 
@@ -654,9 +654,9 @@ Mouseover and click to view `:hover` and `:active` states.
 
 Refer to ghost iconlabel buttons below.
 
-## ghost iconlabel buttons
+## iconlabel ghost buttons
 
-Ghost iconlabel buttons are also used in microinteractions and smaller commands.
+Iconlabel Ghost buttons are also used in microinteractions and smaller commands.
 
 To create an ghost iconlabel button, first create a regular `IconGhostButton`, plus the `iconlabel` prop. Then, if you want the icon to the left of the label, add an icon component inside the button and before its inner text. See our <Link to="/iconography">Iconography</Link> to learn how to use Astro icons.
 


### PR DESCRIPTION
# What

This PR introduces a bunch of quick fixes and easy wins across the docs pages.

- Update buttons sections titles;
- Fix docs page on mobile web;
- Change playground background-color to enhance its contrast;

Also, a couple of improvements regarding code:

- Export iconlabelMargin helper from `IconButton`, avoiding code duplication;
- Move antialising from Text and Heading to global scope 

