### PR TITLE
Introduce Toggle component

### DIFF
--- a/packages/components/src/Toggle/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/components/src/Toggle/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,269 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Toggle should render a disabled toggle button 1`] = `
+.c0 {
+  color: #32383c;
+  background-color: transparent;
+  border: 0;
+  outline: none;
+  cursor: pointer;
+  font: normal normal 400 normal 16px/1.5 Lato,sans-serif;
+}
+
+.c0 span {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 8px;
+}
+
+.c0 span:before {
+  display: block;
+  width: 50px;
+  height: 30px;
+  content: '';
+  background-color: #8296a4;
+  border-radius: 28px;
+  -webkit-transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease;
+}
+
+.c0 span:after {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  display: block;
+  width: 28px;
+  height: 28px;
+  visibility: visible;
+  content: '';
+  background-color: #fff;
+  border-radius: 28px;
+  -webkit-transition: left 0.3s ease;
+  transition: left 0.3s ease;
+}
+
+.c0[aria-pressed]:not(:disabled):hover span:before {
+  background-color: #afbec9;
+}
+
+.c0[aria-pressed='true'] span:before {
+  background-color: #159ce4;
+}
+
+.c0[aria-pressed='true'] span:after {
+  top: 1px;
+  left: 21px;
+}
+
+.c0[aria-pressed='true']:not(:disabled):hover span:before {
+  background-color: #3db5eb;
+}
+
+.c0:disabled {
+  color: #e9eef2;
+  cursor: not-allowed;
+}
+
+.c0:disabled span:before {
+  background-color: #e9eef2;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus span:before {
+  box-shadow: 0 0 0 3px rgba(21,156,228,0.4);
+}
+
+<button
+  aria-pressed={false}
+  className="c0"
+  disabled={true}
+  type="button"
+>
+  resgate total
+  <span
+    aria-hidden="true"
+  />
+</button>
+`;
+
+exports[`Toggle should render a toggle button 1`] = `
+.c0 {
+  color: #32383c;
+  background-color: transparent;
+  border: 0;
+  outline: none;
+  cursor: pointer;
+  font: normal normal 400 normal 16px/1.5 Lato,sans-serif;
+}
+
+.c0 span {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 8px;
+}
+
+.c0 span:before {
+  display: block;
+  width: 50px;
+  height: 30px;
+  content: '';
+  background-color: #8296a4;
+  border-radius: 28px;
+  -webkit-transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease;
+}
+
+.c0 span:after {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  display: block;
+  width: 28px;
+  height: 28px;
+  visibility: visible;
+  content: '';
+  background-color: #fff;
+  border-radius: 28px;
+  -webkit-transition: left 0.3s ease;
+  transition: left 0.3s ease;
+}
+
+.c0[aria-pressed]:not(:disabled):hover span:before {
+  background-color: #afbec9;
+}
+
+.c0[aria-pressed='true'] span:before {
+  background-color: #159ce4;
+}
+
+.c0[aria-pressed='true'] span:after {
+  top: 1px;
+  left: 21px;
+}
+
+.c0[aria-pressed='true']:not(:disabled):hover span:before {
+  background-color: #3db5eb;
+}
+
+.c0:disabled {
+  color: #e9eef2;
+  cursor: not-allowed;
+}
+
+.c0:disabled span:before {
+  background-color: #e9eef2;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus span:before {
+  box-shadow: 0 0 0 3px rgba(21,156,228,0.4);
+}
+
+<button
+  aria-pressed={false}
+  className="c0"
+  type="button"
+>
+  resgate total
+  <span
+    aria-hidden="true"
+  />
+</button>
+`;
+
+exports[`Toggle should render a toggled toggle button 1`] = `
+.c0 {
+  color: #32383c;
+  background-color: transparent;
+  border: 0;
+  outline: none;
+  cursor: pointer;
+  font: normal normal 400 normal 16px/1.5 Lato,sans-serif;
+}
+
+.c0 span {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 8px;
+}
+
+.c0 span:before {
+  display: block;
+  width: 50px;
+  height: 30px;
+  content: '';
+  background-color: #8296a4;
+  border-radius: 28px;
+  -webkit-transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease;
+}
+
+.c0 span:after {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  display: block;
+  width: 28px;
+  height: 28px;
+  visibility: visible;
+  content: '';
+  background-color: #fff;
+  border-radius: 28px;
+  -webkit-transition: left 0.3s ease;
+  transition: left 0.3s ease;
+}
+
+.c0[aria-pressed]:not(:disabled):hover span:before {
+  background-color: #afbec9;
+}
+
+.c0[aria-pressed='true'] span:before {
+  background-color: #159ce4;
+}
+
+.c0[aria-pressed='true'] span:after {
+  top: 1px;
+  left: 21px;
+}
+
+.c0[aria-pressed='true']:not(:disabled):hover span:before {
+  background-color: #3db5eb;
+}
+
+.c0:disabled {
+  color: #e9eef2;
+  cursor: not-allowed;
+}
+
+.c0:disabled span:before {
+  background-color: #e9eef2;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus span:before {
+  box-shadow: 0 0 0 3px rgba(21,156,228,0.4);
+}
+
+<button
+  aria-pressed={true}
+  className="c0"
+  type="button"
+>
+  resgate total
+  <span
+    aria-hidden="true"
+  />
+</button>
+`;

--- a/packages/components/src/Toggle/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/components/src/Toggle/__tests__/__snapshots__/index.test.js.snap
@@ -52,7 +52,6 @@ exports[`Toggle should render a disabled toggle button 1`] = `
 }
 
 .c0[aria-pressed='true'] span:after {
-  top: 1px;
   left: 21px;
 }
 
@@ -142,7 +141,6 @@ exports[`Toggle should render a toggle button 1`] = `
 }
 
 .c0[aria-pressed='true'] span:after {
-  top: 1px;
   left: 21px;
 }
 
@@ -231,7 +229,6 @@ exports[`Toggle should render a toggled toggle button 1`] = `
 }
 
 .c0[aria-pressed='true'] span:after {
-  top: 1px;
   left: 21px;
 }
 

--- a/packages/components/src/Toggle/__tests__/index.test.js
+++ b/packages/components/src/Toggle/__tests__/index.test.js
@@ -13,12 +13,14 @@ describe('Toggle', () => {
       <Toggle isToggled={true} label="resgate total" />
     ).toJSON();
 
+    expect(json.props['aria-pressed']).toBe(true);
     expect(json).toMatchSnapshot();
   });
 
   it('should render a disabled toggle button', () => {
     const json = rendererCreateWithTheme(<Toggle disabled label="resgate total" />).toJSON();
 
+    expect(json.props['disabled']).toBe(true);
     expect(json).toMatchSnapshot();
   });
 });

--- a/packages/components/src/Toggle/__tests__/index.test.js
+++ b/packages/components/src/Toggle/__tests__/index.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import Toggle from '../index';
+
+describe('Toggle', () => {
+  it('should render a toggle button', () => {
+    const json = rendererCreateWithTheme(<Toggle label="resgate total" />).toJSON();
+
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render a toggled toggle button', () => {
+    const json = rendererCreateWithTheme(
+      <Toggle isToggled={true} label="resgate total" />
+    ).toJSON();
+
+    expect(json).toMatchSnapshot();
+  });
+
+  it('should render a disabled toggle button', () => {
+    const json = rendererCreateWithTheme(<Toggle disabled label="resgate total" />).toJSON();
+
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/packages/components/src/Toggle/index.js
+++ b/packages/components/src/Toggle/index.js
@@ -1,0 +1,129 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { space } from 'styled-system';
+
+const TOGGLE_BASE_WIDTH = '50px';
+const TOGGLE_BASE_HEIGHT = '30px';
+const TOGGLE_CIRCLE_SIZE = '28px';
+
+const ToggleButton = styled.button`
+  color: ${props => props.theme.colors.moon900};
+  background-color: transparent;
+  border: 0;
+  outline: none;
+  cursor: pointer;
+  font: ${props => props.theme.fonts.secondary};
+
+  /**
+    Allow us to use custom margin or padding via props if needed.
+    For more info check styled-system docs: https://styled-system.com/theme-specification
+  */
+  ${space};
+
+  span {
+    position: relative;
+    display: inline-block;
+    vertical-align: middle;
+    margin-left: 8px;
+
+    &:before {
+      display: block;
+      width: ${TOGGLE_BASE_WIDTH};
+      height: ${TOGGLE_BASE_HEIGHT};
+      content: '';
+      background-color: ${props => props.theme.colors.moon400};
+      border-radius: ${TOGGLE_CIRCLE_SIZE};
+      transition: background-color 0.3s ease;
+    }
+
+    &:after {
+      position: absolute;
+      top: 1px;
+      left: 1px;
+      display: block;
+      width: ${TOGGLE_CIRCLE_SIZE};
+      height: ${TOGGLE_CIRCLE_SIZE};
+      visibility: visible;
+      content: '';
+      background-color: ${props => props.theme.colors.space100};
+      border-radius: ${TOGGLE_CIRCLE_SIZE};
+      transition: left 0.3s ease;
+    }
+  }
+
+  &[aria-pressed] {
+    :not(:disabled):hover {
+      & span {
+        &:before {
+          background-color: ${props => props.theme.colors.moon300};
+        }
+      }
+    }
+  }
+
+  &[aria-pressed='true'] {
+    & span {
+      &:before {
+        background-color: ${props => props.theme.colors.uranus500};
+      }
+
+      &:after {
+        top: 1px;
+        left: 21px;
+      }
+    }
+
+    :not(:disabled):hover {
+      & span {
+        &:before {
+          background-color: ${props => props.theme.colors.uranus400};
+        }
+      }
+    }
+  }
+
+  :disabled {
+    color: ${props => props.theme.colors.moon200};
+    cursor: not-allowed;
+
+    & span {
+      &:before {
+        background-color: ${props => props.theme.colors.moon200};
+      }
+    }
+  }
+
+  :focus {
+    outline: none;
+
+    & span {
+      &:before {
+        box-shadow: 0 0 0 3px rgba(21, 156, 228, 0.4);
+      }
+    }
+  }
+`;
+
+ToggleButton.displayName = 'ToggleButton';
+
+const Toggle = ({ label, isToggled, ...rest }) => {
+  return (
+    <ToggleButton type="button" aria-pressed={isToggled} {...rest}>
+      {label}
+      <span aria-hidden="true" />
+    </ToggleButton>
+  );
+};
+
+Toggle.propTypes = {
+  label: PropTypes.string.isRequired,
+  isToggled: PropTypes.bool.isRequired,
+  onClick: PropTypes.func,
+};
+
+Toggle.defaultProps = {
+  isToggled: false,
+};
+
+export default Toggle;

--- a/packages/components/src/Toggle/index.js
+++ b/packages/components/src/Toggle/index.js
@@ -69,7 +69,6 @@ const ToggleButton = styled.button`
       }
 
       &:after {
-        top: 1px;
         left: 21px;
       }
     }

--- a/packages/components/src/Toggle/index.story.js
+++ b/packages/components/src/Toggle/index.story.js
@@ -1,0 +1,16 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import Toggle from './index.js';
+
+const ToggleSample = () => {
+  const [isToggled, setToggle] = useState(false);
+
+  return (
+    <>
+      <Toggle label="resgate total" isToggled={isToggled} onClick={() => setToggle(!isToggled)} />
+      <Toggle label="disabled" disabled />
+    </>
+  );
+};
+
+storiesOf('Toggle', module).add('default', () => <ToggleSample />);

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -7,6 +7,7 @@ export { default as IconOutlineButton } from './IconOutlineButton';
 export { default as IconLinkButton } from './IconLinkButton';
 export { default as Text } from './Text';
 export { default as Heading } from './Heading';
+export { default as Toggle } from './Toggle';
 
 export * from './Radio';
 export * from './Checkbox';

--- a/packages/docs/src/components/Menu.js
+++ b/packages/docs/src/components/Menu.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Link } from 'gatsby';
 import { IconDropDown } from '@magnetis/astro-galaxy-icons';

--- a/packages/docs/src/components/Playground.js
+++ b/packages/docs/src/components/Playground.js
@@ -45,7 +45,7 @@ const EditorToggle = styled.button`
   cursor: pointer;
 `;
 
-function Playground({ scope, code, dark }) {
+function Playground({ scope, code, dark, isPlaygroundWithFragment }) {
   const [showEditor, setShowEditor] = useState(false);
 
   function toggleEditor() {
@@ -55,9 +55,13 @@ function Playground({ scope, code, dark }) {
   return (
     <Wrapper dark={dark}>
       <LiveProvider
-        code={`<>
+        code={
+          isPlaygroundWithFragment
+            ? `<>
 ${code}
-</>`}
+</>`
+            : code
+        }
         scope={scope}>
         <PreviewWrapper>
           <LivePreview />
@@ -72,5 +76,9 @@ ${code}
     </Wrapper>
   );
 }
+
+Playground.defaultProps = {
+  isPlaygroundWithFragment: true,
+};
 
 export default Playground;

--- a/packages/docs/src/pages/controls-toggles.mdx
+++ b/packages/docs/src/pages/controls-toggles.mdx
@@ -2,6 +2,7 @@
 title: controls & toggles
 ---
 
+import { useState } from 'react';
 import {
   CheckboxWrapper,
   Checkbox,
@@ -9,6 +10,7 @@ import {
   RadioWrapper,
   Radio,
   RadioShape,
+  Toggle,
   Label,
   Text,
 } from '@magnetis/astro-galaxy-components';
@@ -162,6 +164,73 @@ To create the disabled state, add the disabled attribute on the `Checkbox` compo
           <code>false</code>
         </td>
         <td>Set indeterminate checkbox style.</td>
+      </tr>
+    </tbody>
+  </table>
+</PropsTableWrapper>
+
+## toggles
+
+A simple control that is used to quickly switch between two possible states.
+
+Mouseover to view `:hover` state.
+
+To create the disabled state, add the `disabled` attribute to the `Toggle` component.
+
+<Playground
+  isPlaygroundWithFragment={false}
+  scope={{ Toggle, useState }}
+  code={`
+    () => {
+      const [isToggled, setToggle] = useState(false);
+      return (
+        <>
+          <Toggle label="toggle me" isToggled={isToggled} onClick={() => setToggle(!isToggled)} />
+          <Toggle disabled label="disabled" />
+        </>
+      )
+    }
+  `}
+/>
+
+<Text as="h3">props</Text>
+
+<PropsTableWrapper>
+  <table>
+    <thead>
+      <tr>
+        <th>property</th>
+        <th>PropType</th>
+        <th>required</th>
+        <th>default</th>
+        <th>description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>label</td>
+        <td>string</td>
+        <td>yes</td>
+        <td></td>
+        <td>Toggle's label.</td>
+      </tr>
+      <tr>
+        <td>isToggled</td>
+        <td>boolean</td>
+        <td>yes</td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>Determine if Toggle is toggled.</td>
+      </tr>
+      <tr>
+        <td>onClick</td>
+        <td>function</td>
+        <td>no</td>
+        <td></td>
+        <td>
+          A function that must set the <code>isToggled</code> value to either true or false.
+        </td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
# What

In this PR we are introducing the <q>Toggle</q> component.

It's important to note that we are using a different approach of the [Astro.css' toggle component](https://github.com/magnetis/astro/blob/master/src/css/toggle.css), instead of using an `<input type="checkbox" />`, here we are using a `button` with the `aria-pressed` attribute, and based on that we are styling the toggle accordingly to its specs.

You can find more info about this approach on the Inclusive Components book, or in this link: https://inclusive-components.design/toggle-button/

# Sample

https://deploy-preview-50--astro-galaxy.netlify.com/controls-toggles/
