### PR TITLE
Add input size feature

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,3 +1,4 @@
 import '@storybook/addon-actions/register';
 import '@storybook/addon-backgrounds/register';
+import '@storybook/addon-knobs/register';
 import '@storybook/addon-links/register';

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/preset-react": "^7.0.0",
     "@storybook/addon-actions": "^5.3.17",
     "@storybook/addon-backgrounds": "^5.3.17",
+    "@storybook/addon-knobs": "^5.3.17",
     "@storybook/addon-links": "^5.3.17",
     "@storybook/addons": "^5.3.17",
     "@storybook/react": "^5.3.17",

--- a/packages/components/src/InputGhost/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/components/src/InputGhost/__tests__/__snapshots__/index.test.js.snap
@@ -17,6 +17,7 @@ exports[`InputGhost renders correctly 1`] = `
   -ms-user-select: none;
   user-select: none;
   color: #8296a4;
+  font-size: 16px;
 }
 
 .c1 {
@@ -87,9 +88,9 @@ exports[`InputGhost renders correctly 1`] = `
 .c1:not(:placeholder-shown) + label,
 .c1.--no-animate + label {
   font-weight: 700;
-  -webkit-transform: translate(5%,-10%) scale(0.8);
-  -ms-transform: translate(5%,-10%) scale(0.8);
-  transform: translate(5%,-10%) scale(0.8);
+  -webkit-transform: translate(3px,-6px) scale(0.8);
+  -ms-transform: translate(3px,-6px) scale(0.8);
+  transform: translate(3px,-6px) scale(0.8);
 }
 
 .c1 + label {

--- a/packages/components/src/InputGhost/index.story.js
+++ b/packages/components/src/InputGhost/index.story.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 import InputGhost from './index.js';
 
-storiesOf('InputGhost', module)
+storiesOf('input ghost', module)
   .addParameters({
     backgrounds: [
       { name: 'moon 900', value: theme.colors.moon900, default: true },

--- a/packages/components/src/InputMasked/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/components/src/InputMasked/__tests__/__snapshots__/index.test.js.snap
@@ -17,6 +17,7 @@ exports[`InputMasked renders CPF masked input 1`] = `
   -ms-user-select: none;
   user-select: none;
   color: #8296a4;
+  font-size: 16px;
 }
 
 .c1 {
@@ -87,9 +88,9 @@ exports[`InputMasked renders CPF masked input 1`] = `
 .c1:not(:placeholder-shown) + label,
 .c1.--no-animate + label {
   font-weight: 700;
-  -webkit-transform: translate(5%,-10%) scale(0.8);
-  -ms-transform: translate(5%,-10%) scale(0.8);
-  transform: translate(5%,-10%) scale(0.8);
+  -webkit-transform: translate(3px,-6px) scale(0.8);
+  -ms-transform: translate(3px,-6px) scale(0.8);
+  transform: translate(3px,-6px) scale(0.8);
 }
 
 .c1 + label {
@@ -579,6 +580,7 @@ exports[`InputMasked renders CPF masked input 1`] = `
       className=""
       decimalScale={2}
       inputId="inputId"
+      inputSize="medium"
       isInvalid={false}
       isValidated={false}
       labelId="labelId"
@@ -608,6 +610,7 @@ exports[`InputMasked renders CPF masked input 1`] = `
           <InputText
             className=""
             inputId="inputId"
+            inputSize="medium"
             isInvalid={false}
             isValidated={false}
             labelId="labelId"
@@ -657,6 +660,7 @@ exports[`InputMasked renders CPF masked input 1`] = `
                     aria-labelledby="labelId"
                     className=" --no-animate"
                     id="inputId"
+                    inputSize="medium"
                     isInvalid={false}
                     isValidated={false}
                     onBlur={[Function]}
@@ -686,13 +690,17 @@ exports[`InputMasked renders CPF masked input 1`] = `
                               [Function],
                               ";padding:25px 16px 5px;position:relative;width:100%;",
                               [Function],
+                              ";",
+                              [Function],
                               ";&::placeholder{color:transparent;}&:focus::placeholder,&.--no-animate::placeholder{color:",
                               [Function],
                               ";}&:focus{outline:none;",
                               [Function],
                               ";}&:focus + label{",
                               [Function],
-                              ";}&:focus,&:not(:placeholder-shown),&.--no-animate{& + label{font-weight:700;transform:translate(5%,-10%) scale(0.8);}",
+                              ";}&:focus,&:not(:placeholder-shown),&.--no-animate{& + label{font-weight:700;",
+                              [Function],
+                              ";}",
                               [Function],
                               ";}& + label{left:0;position:absolute;top:0;transition:transform 0.25s,opacity 0.25s ease-in-out;transform-origin:0 0;}",
                             ],
@@ -709,6 +717,7 @@ exports[`InputMasked renders CPF masked input 1`] = `
                       }
                       forwardedRef={null}
                       id="inputId"
+                      inputSize="medium"
                       isInvalid={false}
                       isValidated={false}
                       onBlur={[Function]}
@@ -734,6 +743,7 @@ exports[`InputMasked renders CPF masked input 1`] = `
                   <InputText__InputLabel
                     htmlFor="inputId"
                     id="labelId"
+                    inputSize="medium"
                     isInvalid={false}
                     isValidated={false}
                   >
@@ -752,6 +762,8 @@ exports[`InputMasked renders CPF masked input 1`] = `
                               ";height:4em;padding:1em;pointer-events:none;user-select:none;",
                               [Function],
                               ";",
+                              [Function],
+                              ";",
                             ],
                           },
                           "displayName": "InputText__InputLabel",
@@ -767,6 +779,7 @@ exports[`InputMasked renders CPF masked input 1`] = `
                       forwardedRef={null}
                       htmlFor="inputId"
                       id="labelId"
+                      inputSize="medium"
                       isInvalid={false}
                       isValidated={false}
                     >
@@ -807,6 +820,7 @@ exports[`InputMasked renders currency masked input 1`] = `
   -ms-user-select: none;
   user-select: none;
   color: #8296a4;
+  font-size: 16px;
 }
 
 .c1 {
@@ -877,9 +891,9 @@ exports[`InputMasked renders currency masked input 1`] = `
 .c1:not(:placeholder-shown) + label,
 .c1.--no-animate + label {
   font-weight: 700;
-  -webkit-transform: translate(5%,-10%) scale(0.8);
-  -ms-transform: translate(5%,-10%) scale(0.8);
-  transform: translate(5%,-10%) scale(0.8);
+  -webkit-transform: translate(3px,-6px) scale(0.8);
+  -ms-transform: translate(3px,-6px) scale(0.8);
+  transform: translate(3px,-6px) scale(0.8);
 }
 
 .c1 + label {
@@ -1369,6 +1383,7 @@ exports[`InputMasked renders currency masked input 1`] = `
       className=""
       decimalScale={2}
       inputId="inputId"
+      inputSize="medium"
       isInvalid={false}
       isValidated={false}
       labelId="labelId"
@@ -1419,6 +1434,7 @@ exports[`InputMasked renders currency masked input 1`] = `
           className=""
           inputId="inputId"
           inputMode="numeric"
+          inputSize="medium"
           isInvalid={false}
           isValidated={false}
           labelId="labelId"
@@ -1472,6 +1488,7 @@ exports[`InputMasked renders currency masked input 1`] = `
                   className=" --no-animate"
                   id="inputId"
                   inputMode="numeric"
+                  inputSize="medium"
                   isInvalid={false}
                   isValidated={false}
                   onBlur={[Function]}
@@ -1503,13 +1520,17 @@ exports[`InputMasked renders currency masked input 1`] = `
                             [Function],
                             ";padding:25px 16px 5px;position:relative;width:100%;",
                             [Function],
+                            ";",
+                            [Function],
                             ";&::placeholder{color:transparent;}&:focus::placeholder,&.--no-animate::placeholder{color:",
                             [Function],
                             ";}&:focus{outline:none;",
                             [Function],
                             ";}&:focus + label{",
                             [Function],
-                            ";}&:focus,&:not(:placeholder-shown),&.--no-animate{& + label{font-weight:700;transform:translate(5%,-10%) scale(0.8);}",
+                            ";}&:focus,&:not(:placeholder-shown),&.--no-animate{& + label{font-weight:700;",
+                            [Function],
+                            ";}",
                             [Function],
                             ";}& + label{left:0;position:absolute;top:0;transition:transform 0.25s,opacity 0.25s ease-in-out;transform-origin:0 0;}",
                           ],
@@ -1527,6 +1548,7 @@ exports[`InputMasked renders currency masked input 1`] = `
                     forwardedRef={null}
                     id="inputId"
                     inputMode="numeric"
+                    inputSize="medium"
                     isInvalid={false}
                     isValidated={false}
                     onBlur={[Function]}
@@ -1557,6 +1579,7 @@ exports[`InputMasked renders currency masked input 1`] = `
                 <InputText__InputLabel
                   htmlFor="inputId"
                   id="labelId"
+                  inputSize="medium"
                   isInvalid={false}
                   isValidated={false}
                 >
@@ -1575,6 +1598,8 @@ exports[`InputMasked renders currency masked input 1`] = `
                             ";height:4em;padding:1em;pointer-events:none;user-select:none;",
                             [Function],
                             ";",
+                            [Function],
+                            ";",
                           ],
                         },
                         "displayName": "InputText__InputLabel",
@@ -1590,6 +1615,7 @@ exports[`InputMasked renders currency masked input 1`] = `
                     forwardedRef={null}
                     htmlFor="inputId"
                     id="labelId"
+                    inputSize="medium"
                     isInvalid={false}
                     isValidated={false}
                   >
@@ -1629,6 +1655,7 @@ exports[`InputMasked renders date masked input 1`] = `
   -ms-user-select: none;
   user-select: none;
   color: #8296a4;
+  font-size: 16px;
 }
 
 .c1 {
@@ -1699,9 +1726,9 @@ exports[`InputMasked renders date masked input 1`] = `
 .c1:not(:placeholder-shown) + label,
 .c1.--no-animate + label {
   font-weight: 700;
-  -webkit-transform: translate(5%,-10%) scale(0.8);
-  -ms-transform: translate(5%,-10%) scale(0.8);
-  transform: translate(5%,-10%) scale(0.8);
+  -webkit-transform: translate(3px,-6px) scale(0.8);
+  -ms-transform: translate(3px,-6px) scale(0.8);
+  transform: translate(3px,-6px) scale(0.8);
 }
 
 .c1 + label {
@@ -2191,6 +2218,7 @@ exports[`InputMasked renders date masked input 1`] = `
       className=""
       decimalScale={2}
       inputId="inputId"
+      inputSize="medium"
       isInvalid={false}
       isValidated={false}
       labelId="labelId"
@@ -2220,6 +2248,7 @@ exports[`InputMasked renders date masked input 1`] = `
           <InputText
             className=""
             inputId="inputId"
+            inputSize="medium"
             isInvalid={false}
             isValidated={false}
             labelId="labelId"
@@ -2269,6 +2298,7 @@ exports[`InputMasked renders date masked input 1`] = `
                     aria-labelledby="labelId"
                     className=" --no-animate"
                     id="inputId"
+                    inputSize="medium"
                     isInvalid={false}
                     isValidated={false}
                     onBlur={[Function]}
@@ -2298,13 +2328,17 @@ exports[`InputMasked renders date masked input 1`] = `
                               [Function],
                               ";padding:25px 16px 5px;position:relative;width:100%;",
                               [Function],
+                              ";",
+                              [Function],
                               ";&::placeholder{color:transparent;}&:focus::placeholder,&.--no-animate::placeholder{color:",
                               [Function],
                               ";}&:focus{outline:none;",
                               [Function],
                               ";}&:focus + label{",
                               [Function],
-                              ";}&:focus,&:not(:placeholder-shown),&.--no-animate{& + label{font-weight:700;transform:translate(5%,-10%) scale(0.8);}",
+                              ";}&:focus,&:not(:placeholder-shown),&.--no-animate{& + label{font-weight:700;",
+                              [Function],
+                              ";}",
                               [Function],
                               ";}& + label{left:0;position:absolute;top:0;transition:transform 0.25s,opacity 0.25s ease-in-out;transform-origin:0 0;}",
                             ],
@@ -2321,6 +2355,7 @@ exports[`InputMasked renders date masked input 1`] = `
                       }
                       forwardedRef={null}
                       id="inputId"
+                      inputSize="medium"
                       isInvalid={false}
                       isValidated={false}
                       onBlur={[Function]}
@@ -2346,6 +2381,7 @@ exports[`InputMasked renders date masked input 1`] = `
                   <InputText__InputLabel
                     htmlFor="inputId"
                     id="labelId"
+                    inputSize="medium"
                     isInvalid={false}
                     isValidated={false}
                   >
@@ -2364,6 +2400,8 @@ exports[`InputMasked renders date masked input 1`] = `
                               ";height:4em;padding:1em;pointer-events:none;user-select:none;",
                               [Function],
                               ";",
+                              [Function],
+                              ";",
                             ],
                           },
                           "displayName": "InputText__InputLabel",
@@ -2379,6 +2417,7 @@ exports[`InputMasked renders date masked input 1`] = `
                       forwardedRef={null}
                       htmlFor="inputId"
                       id="labelId"
+                      inputSize="medium"
                       isInvalid={false}
                       isValidated={false}
                     >

--- a/packages/components/src/InputMasked/index.story.js
+++ b/packages/components/src/InputMasked/index.story.js
@@ -2,7 +2,7 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 import InputMasked, { maskTypes } from './index.js';
 
-storiesOf('InputMasked', module)
+storiesOf('input masked', module)
   .add('CPF', () => (
     <InputMasked
       inputId="cpfMaskedInput"

--- a/packages/components/src/InputText/__tests__/__snapshots__/index.js.snap
+++ b/packages/components/src/InputText/__tests__/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`InputText renders correctly the input without animation 1`] = `
+exports[`input text renders correctly the input without animation 1`] = `
 .c0 {
   border: 0;
   padding: 0;
@@ -17,6 +17,7 @@ exports[`InputText renders correctly the input without animation 1`] = `
   -ms-user-select: none;
   user-select: none;
   color: #8296a4;
+  font-size: 16px;
 }
 
 .c1 {
@@ -87,9 +88,9 @@ exports[`InputText renders correctly the input without animation 1`] = `
 .c1:not(:placeholder-shown) + label,
 .c1.--no-animate + label {
   font-weight: 700;
-  -webkit-transform: translate(5%,-10%) scale(0.8);
-  -ms-transform: translate(5%,-10%) scale(0.8);
-  transform: translate(5%,-10%) scale(0.8);
+  -webkit-transform: translate(3px,-6px) scale(0.8);
+  -ms-transform: translate(3px,-6px) scale(0.8);
+  transform: translate(3px,-6px) scale(0.8);
 }
 
 .c1 + label {
@@ -108,23 +109,23 @@ exports[`InputText renders correctly the input without animation 1`] = `
   className="c0"
 >
   <input
-    aria-labelledby="label4"
+    aria-labelledby="labelId"
     className="c1  --no-animate"
-    id="input4"
+    id="inputId"
     placeholder="Standard"
     type="text"
   />
   <label
     className="c2"
-    htmlFor="input4"
-    id="label4"
+    htmlFor="inputId"
+    id="labelId"
   >
     Standard
   </label>
 </fieldset>
 `;
 
-exports[`InputText renders correctly the invalid input 1`] = `
+exports[`input text renders correctly the invalid input 1`] = `
 .c3 {
   fill: currentcolor;
   color: #d45459;
@@ -146,6 +147,7 @@ exports[`InputText renders correctly the invalid input 1`] = `
   -ms-user-select: none;
   user-select: none;
   color: #d45459;
+  font-size: 16px;
 }
 
 .c1 {
@@ -159,6 +161,7 @@ exports[`InputText renders correctly the invalid input 1`] = `
   position: relative;
   width: 100%;
   border-color: #d45459;
+  padding-right: 48px;
 }
 
 .c1::-webkit-input-placeholder {
@@ -200,6 +203,7 @@ exports[`InputText renders correctly the invalid input 1`] = `
 .c1:focus {
   outline: none;
   border-color: #d45459;
+  padding-right: 48px;
 }
 
 .c1:focus + label {
@@ -210,15 +214,16 @@ exports[`InputText renders correctly the invalid input 1`] = `
 .c1:not(:placeholder-shown),
 .c1.--no-animate {
   border-color: #d45459;
+  padding-right: 48px;
 }
 
 .c1:focus + label,
 .c1:not(:placeholder-shown) + label,
 .c1.--no-animate + label {
   font-weight: 700;
-  -webkit-transform: translate(5%,-10%) scale(0.8);
-  -ms-transform: translate(5%,-10%) scale(0.8);
-  transform: translate(5%,-10%) scale(0.8);
+  -webkit-transform: translate(3px,-6px) scale(0.8);
+  -ms-transform: translate(3px,-6px) scale(0.8);
+  transform: translate(3px,-6px) scale(0.8);
 }
 
 .c1 + label {
@@ -244,17 +249,17 @@ exports[`InputText renders correctly the invalid input 1`] = `
   className="c0"
 >
   <input
-    aria-labelledby="label3"
+    aria-labelledby="labelId"
     className="c1  "
     defaultValue="Astro Team"
-    id="input3"
+    id="inputId"
     placeholder="Invalid"
     type="text"
   />
   <label
     className="c2"
-    htmlFor="input3"
-    id="label3"
+    htmlFor="inputId"
+    id="labelId"
   >
     Invalid
   </label>
@@ -266,7 +271,7 @@ exports[`InputText renders correctly the invalid input 1`] = `
       Object {
         "position": "absolute",
         "right": "8px",
-        "top": "12px",
+        "top": "10px",
       }
     }
     viewBox="0 0 32 32"
@@ -303,7 +308,7 @@ exports[`InputText renders correctly the invalid input 1`] = `
 </fieldset>
 `;
 
-exports[`InputText renders correctly the standard input 1`] = `
+exports[`input text renders correctly the large input and checks its font size 1`] = `
 .c0 {
   border: 0;
   padding: 0;
@@ -320,6 +325,134 @@ exports[`InputText renders correctly the standard input 1`] = `
   -ms-user-select: none;
   user-select: none;
   color: #8296a4;
+  font-size: 24px;
+  padding: 0.6em;
+}
+
+.c1 {
+  background-color: #ffffff;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 8px;
+  color: #32383c;
+  font: normal normal 400 normal 16px/1.5 Lato,sans-serif;
+  padding: 25px 16px 5px;
+  position: relative;
+  width: 100%;
+  border-color: #597183;
+  font-size: 24px;
+}
+
+.c1::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.c1::-moz-placeholder {
+  color: transparent;
+}
+
+.c1:-ms-input-placeholder {
+  color: transparent;
+}
+
+.c1::placeholder {
+  color: transparent;
+}
+
+.c1:focus::-webkit-input-placeholder,
+.c1.--no-animate::-webkit-input-placeholder {
+  color: #afbec9;
+}
+
+.c1:focus::-moz-placeholder,
+.c1.--no-animate::-moz-placeholder {
+  color: #afbec9;
+}
+
+.c1:focus:-ms-input-placeholder,
+.c1.--no-animate:-ms-input-placeholder {
+  color: #afbec9;
+}
+
+.c1:focus::placeholder,
+.c1.--no-animate::placeholder {
+  color: #afbec9;
+}
+
+.c1:focus {
+  outline: none;
+  border-color: #597183;
+}
+
+.c1:focus + label {
+  color: #159ce4;
+}
+
+.c1:focus,
+.c1:not(:placeholder-shown),
+.c1.--no-animate {
+  border-color: #159ce4;
+}
+
+.c1:focus + label,
+.c1:not(:placeholder-shown) + label,
+.c1.--no-animate + label {
+  font-weight: 700;
+  -webkit-transform: translate(8px,-3px) scale(0.6);
+  -ms-transform: translate(8px,-3px) scale(0.6);
+  transform: translate(8px,-3px) scale(0.6);
+}
+
+.c1 + label {
+  left: 0;
+  position: absolute;
+  top: 0;
+  -webkit-transition: -webkit-transform 0.25s,opacity 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s,opacity 0.25s ease-in-out;
+  transition: transform 0.25s,opacity 0.25s ease-in-out;
+  -webkit-transform-origin: 0 0;
+  -ms-transform-origin: 0 0;
+  transform-origin: 0 0;
+}
+
+<fieldset
+  className="c0"
+>
+  <input
+    aria-labelledby="labelId"
+    className="c1  "
+    id="inputId"
+    placeholder="Standard"
+    type="text"
+  />
+  <label
+    className="c2"
+    htmlFor="inputId"
+    id="labelId"
+  >
+    Standard
+  </label>
+</fieldset>
+`;
+
+exports[`input text renders correctly the standard input 1`] = `
+.c0 {
+  border: 0;
+  padding: 0;
+  position: relative;
+}
+
+.c2 {
+  font: normal normal 400 normal 16px/1.5 Lato,sans-serif;
+  height: 4em;
+  padding: 1em;
+  pointer-events: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  color: #8296a4;
+  font-size: 16px;
 }
 
 .c1 {
@@ -390,9 +523,9 @@ exports[`InputText renders correctly the standard input 1`] = `
 .c1:not(:placeholder-shown) + label,
 .c1.--no-animate + label {
   font-weight: 700;
-  -webkit-transform: translate(5%,-10%) scale(0.8);
-  -ms-transform: translate(5%,-10%) scale(0.8);
-  transform: translate(5%,-10%) scale(0.8);
+  -webkit-transform: translate(3px,-6px) scale(0.8);
+  -ms-transform: translate(3px,-6px) scale(0.8);
+  transform: translate(3px,-6px) scale(0.8);
 }
 
 .c1 + label {
@@ -411,23 +544,23 @@ exports[`InputText renders correctly the standard input 1`] = `
   className="c0"
 >
   <input
-    aria-labelledby="label1"
+    aria-labelledby="labelId"
     className="c1  "
-    id="input1"
+    id="inputId"
     placeholder="Standard"
     type="text"
   />
   <label
     className="c2"
-    htmlFor="input1"
-    id="label1"
+    htmlFor="inputId"
+    id="labelId"
   >
     Standard
   </label>
 </fieldset>
 `;
 
-exports[`InputText renders correctly the validated input 1`] = `
+exports[`input text renders correctly the validated input 1`] = `
 .c3 {
   fill: currentcolor;
   color: #74e24a;
@@ -449,6 +582,7 @@ exports[`InputText renders correctly the validated input 1`] = `
   -ms-user-select: none;
   user-select: none;
   color: #74e24a;
+  font-size: 16px;
 }
 
 .c1 {
@@ -462,6 +596,7 @@ exports[`InputText renders correctly the validated input 1`] = `
   position: relative;
   width: 100%;
   border-color: #74e24a;
+  padding-right: 48px;
 }
 
 .c1::-webkit-input-placeholder {
@@ -503,6 +638,7 @@ exports[`InputText renders correctly the validated input 1`] = `
 .c1:focus {
   outline: none;
   border-color: #74e24a;
+  padding-right: 48px;
 }
 
 .c1:focus + label {
@@ -513,15 +649,16 @@ exports[`InputText renders correctly the validated input 1`] = `
 .c1:not(:placeholder-shown),
 .c1.--no-animate {
   border-color: #74e24a;
+  padding-right: 48px;
 }
 
 .c1:focus + label,
 .c1:not(:placeholder-shown) + label,
 .c1.--no-animate + label {
   font-weight: 700;
-  -webkit-transform: translate(5%,-10%) scale(0.8);
-  -ms-transform: translate(5%,-10%) scale(0.8);
-  transform: translate(5%,-10%) scale(0.8);
+  -webkit-transform: translate(3px,-6px) scale(0.8);
+  -ms-transform: translate(3px,-6px) scale(0.8);
+  transform: translate(3px,-6px) scale(0.8);
 }
 
 .c1 + label {
@@ -540,17 +677,17 @@ exports[`InputText renders correctly the validated input 1`] = `
   className="c0"
 >
   <input
-    aria-labelledby="label2"
+    aria-labelledby="labelId"
     className="c1  "
     defaultValue="Astro Team"
-    id="input2"
+    id="inputId"
     placeholder="Validated"
     type="text"
   />
   <label
     className="c2"
-    htmlFor="input2"
-    id="label2"
+    htmlFor="inputId"
+    id="labelId"
   >
     Validated
   </label>
@@ -562,7 +699,7 @@ exports[`InputText renders correctly the validated input 1`] = `
       Object {
         "position": "absolute",
         "right": "8px",
-        "top": "12px",
+        "top": "10px",
       }
     }
     viewBox="0 0 32 32"

--- a/packages/components/src/InputText/__tests__/index.js
+++ b/packages/components/src/InputText/__tests__/index.js
@@ -1,20 +1,24 @@
+import { theme } from '@magnetis/astro-galaxy-core';
 import React from 'react';
-import InputText from '../index';
+import InputText, { inputSizes } from '../index';
 
 function mount(props = {}) {
-  return rendererCreateWithTheme(<InputText {...props} />).toJSON();
+  const mergedProps = {
+    inputId: 'inputId',
+    labelId: 'labelId',
+    ...props,
+  };
+  return rendererCreateWithTheme(<InputText {...mergedProps} />).toJSON();
 }
 
-describe('InputText', () => {
+describe('input text', () => {
   it('renders correctly the standard input', () => {
-    const wrapper = mount({ inputId: 'input1', labelId: 'label1' });
+    const wrapper = mount();
     expect(wrapper).toMatchSnapshot();
   });
 
   it('renders correctly the validated input', () => {
     const wrapper = mount({
-      inputId: 'input2',
-      labelId: 'label2',
       isValidated: true,
       labelText: 'Validated',
       defaultValue: 'Astro Team',
@@ -24,19 +28,23 @@ describe('InputText', () => {
 
   it('renders correctly the invalid input', () => {
     const wrapper = mount({
-      inputId: 'input3',
-      labelId: 'label3',
       isInvalid: true,
       labelText: 'Invalid',
       defaultValue: 'Astro Team',
       errorMessage: 'Invalid data',
     });
-
     expect(wrapper).toMatchSnapshot();
   });
 
   it('renders correctly the input without animation', () => {
-    const wrapper = mount({ inputId: 'input4', labelId: 'label4', noAnimate: true });
+    const wrapper = mount({ noAnimate: true });
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders correctly the large input and checks its font size', () => {
+    const wrapper = mount({ inputSize: inputSizes.large });
+    const input = wrapper.children[0];
+    expect(input).toHaveStyleRule('font-size', theme.fontSizes.texts.large);
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/packages/components/src/InputText/index.js
+++ b/packages/components/src/InputText/index.js
@@ -4,6 +4,33 @@ import React from 'react';
 import styled from 'styled-components';
 import { layout, space } from 'styled-system';
 
+export const inputSizes = {
+  medium: 'medium',
+  large: 'large',
+};
+
+const inputSizeStyles = props => {
+  if (props.inputSize === inputSizes.large) {
+    return {
+      label: {
+        initial: `
+          font-size: ${props.theme.fontSizes.texts.large};
+          padding: 0.6em;
+        `,
+        focus: `transform: translate(8px, -3px) scale(0.6);`,
+      },
+      input: `font-size: ${props.theme.fontSizes.texts.large};`,
+    };
+  }
+
+  return {
+    label: {
+      initial: `font-size: ${props.theme.fontSizes.texts.medium};`,
+      focus: `transform: translate(3px, -6px) scale(0.8);`,
+    },
+  };
+};
+
 const labelValidationStyles = props => {
   if (props.isValidated && !props.disabled) {
     return `color: ${props.theme.colors.earth400}`;
@@ -24,12 +51,14 @@ const labelValidationStyles = props => {
 };
 
 const inputValidationStyles = props => {
+  const iconPadding = props.theme.space[6];
+
   if (props.isValidated && !props.disabled) {
-    return `border-color: ${props.theme.colors.earth400}`;
+    return `border-color: ${props.theme.colors.earth400}; padding-right: ${iconPadding}px;`;
   }
 
   if (props.isInvalid && !props.disabled) {
-    return `border-color: ${props.theme.colors.mars500}`;
+    return `border-color: ${props.theme.colors.mars500}; padding-right: ${iconPadding}px;`;
   }
 
   if (props.disabled) {
@@ -61,6 +90,7 @@ const InputLabel = styled.label`
   user-select: none;
 
   ${props => labelValidationStyles({ ...props, defaultColor: props.theme.colors.moon400 })};
+  ${props => inputSizeStyles(props).label.initial};
 `;
 
 const InputField = styled.input`
@@ -75,6 +105,7 @@ const InputField = styled.input`
   width: 100%;
 
   ${props => inputValidationStyles({ ...props, defaultColor: props.theme.colors.moon500 })};
+  ${props => inputSizeStyles(props).input};
 
   &::placeholder {
     color: transparent;
@@ -100,7 +131,8 @@ const InputField = styled.input`
   &.--no-animate {
     & + label {
       font-weight: 700;
-      transform: translate(5%, -10%) scale(0.8);
+
+      ${props => inputSizeStyles(props).label.focus};
     }
     ${props => inputValidationStyles({ ...props, defaultColor: props.theme.colors.uranus500 })};
   }
@@ -114,11 +146,11 @@ const InputField = styled.input`
   }
 `;
 
-const iconStyles = {
+const iconStyles = inputSize => ({
   position: 'absolute',
-  top: '12px',
+  top: `${inputSize === inputSizes.large ? 16 : 10}px`,
   right: '8px',
-};
+});
 
 const ErrorMessage = styled.div`
   color: ${props => props.theme.colors.mars500};
@@ -137,6 +169,7 @@ const InputText = ({
   labelProps,
   noAnimate,
   className,
+  inputSize,
   ...rest
 }) => (
   <>
@@ -148,6 +181,7 @@ const InputText = ({
         placeholder={labelText}
         isValidated={isValidated}
         isInvalid={isInvalid}
+        inputSize={inputSize}
         className={`${className} ${noAnimate ? '--no-animate' : ''}`}
         {...rest}
       />
@@ -156,11 +190,14 @@ const InputText = ({
         htmlFor={inputId}
         isValidated={isValidated}
         isInvalid={isInvalid}
+        inputSize={inputSize}
         {...labelProps}>
         {labelText}
       </InputLabel>
-      {isValidated && <IconCircleCheck color="earth400" size="32" style={{ ...iconStyles }} />}
-      {isInvalid && <IconAlert color="mars500" size="32" style={{ ...iconStyles }} />}
+      {isValidated && (
+        <IconCircleCheck color="earth400" size="32" style={{ ...iconStyles(inputSize) }} />
+      )}
+      {isInvalid && <IconAlert color="mars500" size="32" style={{ ...iconStyles(inputSize) }} />}
       {isInvalid && errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
     </InputWrapper>
   </>
@@ -176,6 +213,7 @@ InputText.defaultProps = {
   noAnimate: false,
   labelProps: {},
   className: '',
+  inputSize: inputSizes.medium,
 };
 
 InputText.propTypes = {
@@ -187,6 +225,7 @@ InputText.propTypes = {
   noAnimate: PropTypes.bool,
   errorMessage: PropTypes.string,
   labelProps: PropTypes.object,
+  inputSize: PropTypes.oneOf([inputSizes.medium, inputSizes.large]),
 };
 
 export default InputText;

--- a/packages/components/src/InputText/index.story.js
+++ b/packages/components/src/InputText/index.story.js
@@ -1,31 +1,61 @@
+import { boolean, radios, text, withKnobs } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
-import InputText from './index.js';
+import InputText, { inputSizes } from './index.js';
 
-storiesOf('InputText', module)
-  .add('default', () => <InputText inputId="input0" labelId="label0" />)
+const buildProps = (props = {}) => ({
+  inputId: 'inputId',
+  labelId: 'labelId',
+  labelText: text('label', 'Label'),
+  placeholder: text('placeholder', 'Placeholder'),
+  inputSize: radios('size', inputSizes, inputSizes.medium),
+  noAnimate: boolean('no animate', false),
+  isValidated: boolean('is validated', false),
+  isInvalid: boolean('is invalid', false),
+  errorMessage: text('error message', 'Invalid data'),
+  disabled: boolean('disabled', false),
+  ...props,
+});
+
+storiesOf('input text', module)
+  .addDecorator(withKnobs)
+  .add('default', () => <InputText {...buildProps()} />)
   .add('validated', () => (
     <InputText
-      inputId="input1"
-      labelId="label1"
-      labelText="Validated"
+      {...buildProps({
+        labelText: text('label', 'Validated'),
+        isValidated: boolean('is validated', true),
+      })}
       defaultValue="Astro Team"
-      isValidated
     />
   ))
   .add('invalid', () => (
     <InputText
-      inputId="input2"
-      labelId="label2"
-      labelText="Invalid"
-      defaultValue="Astro Team"
-      errorMessage="Invalid data"
-      isInvalid
+      {...buildProps({
+        labelText: text('label', 'Invalid'),
+        isInvalid: boolean('is invalid', true),
+      })}
+      defaultValue="XYZK2"
     />
   ))
   .add('disabled', () => (
-    <InputText inputId="input3" labelId="label3" labelText="Disabled" disabled />
+    <InputText
+      {...buildProps({
+        disabled: boolean('disabled', true),
+      })}
+    />
   ))
   .add('without animation', () => (
-    <InputText inputId="input4" labelId="label4" placeholder="Placeholder" noAnimate />
+    <InputText
+      {...buildProps({
+        noAnimate: boolean('no animate', true),
+      })}
+    />
+  ))
+  .add('large size', () => (
+    <InputText
+      {...buildProps({
+        inputSize: radios('size', inputSizes, inputSizes.large),
+      })}
+    />
   ));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1610,7 +1610,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5":
+"@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
   integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
@@ -1750,7 +1750,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@emotion/cache@^10.0.27":
+"@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
   integrity sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==
@@ -1760,7 +1760,7 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/core@^10.0.20":
+"@emotion/core@^10.0.20", "@emotion/core@^10.0.9":
   version "10.0.28"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.28.tgz#bb65af7262a234593a9e952c041d0f1c9b9bef3d"
   integrity sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==
@@ -1772,7 +1772,7 @@
     "@emotion/sheet" "0.9.4"
     "@emotion/utils" "0.11.3"
 
-"@emotion/css@^10.0.27":
+"@emotion/css@^10.0.27", "@emotion/css@^10.0.9":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
   integrity sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==
@@ -1972,6 +1972,11 @@
   integrity sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
   dependencies:
     "@hapi/hoek" "^8.3.0"
+
+"@icons/material@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
+  integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
 
 "@jest/console@^24.7.1":
   version "24.7.1"
@@ -3256,6 +3261,30 @@
     react "^16.8.3"
     util-deprecate "^1.0.2"
 
+"@storybook/addon-knobs@^5.3.17":
+  version "5.3.17"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-5.3.17.tgz#5c255a1369bfec898c2a6ea7de904b3eeb7a31d1"
+  integrity sha512-SMjvH3EjUbt4Xn1Q22thXVQSDrJRUB3IAzhUNdBovFB3RwOXmRFd0iSHC3TTKJfW2TYPssl8cnNGQTH6O2d14g==
+  dependencies:
+    "@storybook/addons" "5.3.17"
+    "@storybook/api" "5.3.17"
+    "@storybook/client-api" "5.3.17"
+    "@storybook/components" "5.3.17"
+    "@storybook/core-events" "5.3.17"
+    "@storybook/theming" "5.3.17"
+    "@types/react-color" "^3.0.1"
+    copy-to-clipboard "^3.0.8"
+    core-js "^3.0.1"
+    escape-html "^1.0.3"
+    fast-deep-equal "^2.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    prop-types "^15.7.2"
+    qs "^6.6.0"
+    react-color "^2.17.0"
+    react-lifecycles-compat "^3.0.4"
+    react-select "^3.0.8"
+
 "@storybook/addon-links@^5.3.17":
   version "5.3.17"
   resolved "https://registry.yarnpkg.com/@storybook/addon-links/-/addon-links-5.3.17.tgz#bccbd49108f03eb8f7a72106fbbceed671e042a9"
@@ -4031,6 +4060,13 @@
   integrity sha512-Oh5DAVr/L2svBvubw6QEFpXGu295Y406BPs4i9t1n2pp7M+q3pmCmhzb9oZV5wncR41KCD3NHl1Yhi7uKnTPsA==
   dependencies:
     "@types/history" "*"
+    "@types/react" "*"
+
+"@types/react-color@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-color/-/react-color-3.0.1.tgz#5433e2f503ea0e0831cbc6fd0c20f8157d93add0"
+  integrity sha512-J6mYm43Sid9y+OjZ7NDfJ2VVkeeuTPNVImNFITgQNXodHteKfl/t/5pAR5Z9buodZ2tCctsZjgiMlQOpfntakw==
+  dependencies:
     "@types/react" "*"
 
 "@types/react-dom@*":
@@ -8039,6 +8075,11 @@ csstype@^2.5.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.5.tgz#1cd1dff742ebf4d7c991470ae71e12bb6751e034"
   integrity sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA==
 
+csstype@^2.6.7:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
+  integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -8586,6 +8627,14 @@ dom-helpers@^3.2.1:
   dependencies:
     "@babel/runtime" "^7.1.2"
 
+dom-helpers@^5.0.1:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.1.3.tgz#7233248eb3a2d1f74aafca31e52c5299cc8ce821"
+  integrity sha512-nZD1OtwfWGRBWlpANxacBEZrEuLa16o1nh7YopFWeoF68Zt8GGEmzHu6Xv4F3XaFIC+YXtTLrzgqKxFgLEe4jw==
+  dependencies:
+    "@babel/runtime" "^7.6.3"
+    csstype "^2.6.7"
+
 dom-iterator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dom-iterator/-/dom-iterator-1.0.0.tgz#9c09899846ec41c2d257adc4d6015e4759ef05ad"
@@ -9112,7 +9161,7 @@ es6-shim@^0.35.5:
   resolved "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.5.tgz#46f59dc0a84a1c5029e8ff1166ca0a902077a9ab"
   integrity sha512-E9kK/bjtCQRpN1K28Xh4BlmP8egvZBGJJ+9GtnzOwt7mdqtrjHFuVGr7QJfdjBIKqrlU5duPf3pCBoDrkjVYFg==
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
@@ -14084,7 +14133,7 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.11.1, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.3.0:
+lodash@^4.0.1, lodash@^4.11.1, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -14369,6 +14418,11 @@ markdown-to-jsx@^6.9.1, markdown-to-jsx@^6.9.3:
   dependencies:
     prop-types "^15.6.2"
     unquote "^1.1.0"
+
+material-colors@^1.2.1:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
+  integrity sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==
 
 md5-file@^3.2.3:
   version "3.2.3"
@@ -17412,6 +17466,18 @@ react-clientside-effect@^1.2.2:
   dependencies:
     "@babel/runtime" "^7.0.0"
 
+react-color@^2.17.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.18.0.tgz#34956f0bac394f6c3bc01692fd695644cc775ffd"
+  integrity sha512-FyVeU1kQiSokWc8NPz22azl1ezLpJdUyTbWL0LPUpcuuYDrZ/Y1veOk9rRK5B3pMlyDGvTk4f4KJhlkIQNRjEA==
+  dependencies:
+    "@icons/material" "^0.2.4"
+    lodash "^4.17.11"
+    material-colors "^1.2.1"
+    prop-types "^15.5.10"
+    reactcss "^1.2.0"
+    tinycolor2 "^1.4.1"
+
 react-dev-utils@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-4.2.3.tgz#5b42d9ea58d5e9e017a2f57a40a8af408a3a46fb"
@@ -17578,6 +17644,13 @@ react-hotkeys@2.0.0:
   dependencies:
     prop-types "^15.6.1"
 
+react-input-autosize@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"
+  integrity sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==
+  dependencies:
+    prop-types "^15.5.8"
+
 react-input-mask@^3.0.0-alpha.2:
   version "3.0.0-alpha.2"
   resolved "https://registry.yarnpkg.com/react-input-mask/-/react-input-mask-3.0.0-alpha.2.tgz#113102942a557edc7a192e66020b8ce1ba699a5c"
@@ -17657,6 +17730,20 @@ react-reconciler@^0.24.0:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
+react-select@^3.0.8:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.1.0.tgz#ab098720b2e9fe275047c993f0d0caf5ded17c27"
+  integrity sha512-wBFVblBH1iuCBprtpyGtd1dGMadsG36W5/t2Aj8OE6WbByDg5jIFyT7X5gT+l0qmT5TqWhxX+VsKJvCEl2uL9g==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@emotion/cache" "^10.0.9"
+    "@emotion/core" "^10.0.9"
+    "@emotion/css" "^10.0.9"
+    memoize-one "^5.0.0"
+    prop-types "^15.6.0"
+    react-input-autosize "^2.2.2"
+    react-transition-group "^4.3.0"
+
 react-side-effect@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.2.0.tgz#0e940c78faba0c73b9b0eba9cd3dda8dfb7e7dae"
@@ -17718,6 +17805,16 @@ react-textarea-autosize@^7.1.0:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
 
+react-transition-group@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.3.0.tgz#fea832e386cf8796c58b61874a3319704f5ce683"
+  integrity sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+
 react@^16.12.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
@@ -17736,6 +17833,13 @@ react@^16.8.3:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.6"
+
+reactcss@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/reactcss/-/reactcss-1.2.3.tgz#c00013875e557b1cf0dfd9a368a1c3dab3b548dd"
+  integrity sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==
+  dependencies:
+    lodash "^4.0.1"
 
 read-chunk@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
# What

This PR adds a large-sized input variation. This new size will be available to all components based on `InputText`.

# Why

The Design team may prefer this alternative for small screens.

# How

* Adds input size variation to the component
* Adds Storybook knobs addon (to allow to change the input size - and other props - in real-time)
* Adds sample on Storybook and test to check the size
* Minor naming adjustments on some component titles on the Storybook menu

# Sample

<img width="1438" alt="Captura de Tela 2020-03-26 às 12 01 18" src="https://user-images.githubusercontent.com/1002072/77663742-2cf2b780-6f5c-11ea-9d94-bd3a5da5c72b.png">

# Refs

* [Clubhouse card](https://app.clubhouse.io/magnetis/story/23904/criar-variações-de-tamanho-dos-inputs) [ch23904]