### PR TITLE
Add table component

### DIFF
--- a/packages/components/src/Table/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/components/src/Table/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Table should render correctly 1`] = `
+.c0 {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.c0 td {
+  color: #32383c;
+  font: normal normal 400 normal 16px/1.5 Lato,sans-serif;
+}
+
+.c0 th {
+  color: #597183;
+  font: normal normal 600 normal 16px/1.5 Poppins,sans-serif;
+}
+
+.c0 td,
+.c0 th {
+  padding: 32px 16px;
+  text-align: inherit;
+}
+
+.c0 td:first-child,
+.c0 th:first-child {
+  padding-left: 32px;
+}
+
+.c0 td:last-child,
+.c0 th:last-child {
+  padding-right: 32px;
+}
+
+.c0 tr:nth-child(odd) td {
+  background-color: #1c212408;
+}
+
+.c0 tr[disabled] {
+  opacity: 0.3;
+}
+
+<table
+  className="c0"
+/>
+`;

--- a/packages/components/src/Table/__tests__/index.test.js
+++ b/packages/components/src/Table/__tests__/index.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import Table from '..';
+
+describe('Table', () => {
+  it('should render correctly', () => {
+    const component = rendererCreateWithTheme(<Table />).toJSON();
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/packages/components/src/Table/index.js
+++ b/packages/components/src/Table/index.js
@@ -1,0 +1,60 @@
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const tableTheme = props =>
+  props.darkMode
+    ? {
+        headColor: props.theme.colors.moon300,
+        cellColor: props.theme.colors.moon100,
+        rowColor: `${props.theme.colors.moon100}16`,
+      }
+    : {
+        headColor: props.theme.colors.moon500,
+        cellColor: props.theme.colors.moon900,
+        rowColor: `${props.theme.colors.moon1000}08`,
+      };
+
+const Table = styled.table`
+  border-collapse: collapse;
+  width: 100%;
+
+  td {
+    color: ${props => tableTheme(props).cellColor};
+    font: ${props => props.theme.fonts.secondary};
+  }
+
+  th {
+    color: ${props => tableTheme(props).headColor};
+    font: ${props => props.theme.fonts.primary};
+  }
+
+  td,
+  th {
+    padding: ${props => props.theme.space[4]}px ${props => props.theme.space[2]}px;
+    text-align: inherit;
+
+    &:first-child {
+      padding-left: ${props => props.theme.space[4]}px;
+    }
+
+    &:last-child {
+      padding-right: ${props => props.theme.space[4]}px;
+    }
+  }
+
+  tr:nth-child(odd) td {
+    background-color: ${props => tableTheme(props).rowColor};
+  }
+
+  tr[disabled] {
+    opacity: 0.3;
+  }
+`;
+
+Table.displayName = 'Table';
+
+Table.propTypes = {
+  darkMode: PropTypes.bool,
+};
+
+export default Table;

--- a/packages/components/src/Table/index.story.js
+++ b/packages/components/src/Table/index.story.js
@@ -1,0 +1,73 @@
+import { theme } from '@magnetis/astro-galaxy-core';
+import { IconPencil, IconTrash } from '@magnetis/astro-galaxy-icons';
+import { boolean, withKnobs } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+import Table from '.';
+import IconGhostButton from '../IconGhostButton';
+
+const backgroundSelector = darkMode => ({
+  backgrounds: [
+    { name: 'space 100', value: theme.colors.space100, default: !darkMode },
+    { name: 'moon 900', value: theme.colors.moon900, default: darkMode },
+  ],
+});
+
+const DemoTable = props => (
+  <Table darkMode={boolean('dark mode', props.darkMode)}>
+    <thead>
+      <tr>
+        <th>Category</th>
+        <th>Fund</th>
+        <th>Investment</th>
+        <th>&nbsp;</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Monthly Income</td>
+        <td>FI Alaska Private Plus</td>
+        <td>$ 87,900.00</td>
+        <td>
+          <IconGhostButton variant="ghost.uranus">
+            <IconPencil />
+          </IconGhostButton>
+          <IconGhostButton variant="ghost.mars">
+            <IconTrash />
+          </IconGhostButton>
+        </td>
+      </tr>
+      <tr>
+        <td>Retirement Plan</td>
+        <td>Icatu FAFI Future</td>
+        <td>$ 143,273.00</td>
+        <td>
+          <IconGhostButton variant="ghost.uranus">
+            <IconPencil />
+          </IconGhostButton>
+          <IconGhostButton variant="ghost.mars">
+            <IconTrash />
+          </IconGhostButton>
+        </td>
+      </tr>
+      <tr disabled>
+        <td>Stocks</td>
+        <td>ETF Small 11</td>
+        <td>$ 1,230.35</td>
+        <td>
+          <IconGhostButton variant="ghost.uranus">
+            <IconPencil />
+          </IconGhostButton>
+          <IconGhostButton variant="ghost.mars">
+            <IconTrash />
+          </IconGhostButton>
+        </td>
+      </tr>
+    </tbody>
+  </Table>
+);
+
+storiesOf('table', module)
+  .addDecorator(withKnobs)
+  .add('default', () => <DemoTable />, backgroundSelector(false))
+  .add('dark mode', () => <DemoTable darkMode />, backgroundSelector(true));


### PR DESCRIPTION
# What

This code adds the table component in Astro Galaxy.

# Why

For displaying tabular data.

# How

* Add component, with style and test
* Add variant for a dark mode (many of our screens have a dark background)

# Sample

| Default mode |
| --- |
| <img width="1277" alt="Captura de Tela 2020-03-27 às 18 09 30" src="https://user-images.githubusercontent.com/1002072/77802894-9f49c180-705a-11ea-9cca-c1dfe7583a30.png"> |

| Dark mode |
| --- |
| <img width="1279" alt="Captura de Tela 2020-03-27 às 18 09 52" src="https://user-images.githubusercontent.com/1002072/77802901-a53fa280-705a-11ea-9278-15334d5dabf6.png"> |

# Refs

* [Clubhouse card](https://app.clubhouse.io/magnetis/story/23905/criar-tabela-padrão-no-galaxy) [ch23905]
* [Astro vanilla ref](http://astro.magnetis.com.br/tables)