### PR TITLE
Add Storybook refinements

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,8 +1,21 @@
-import React from 'react';
-import { configure, addDecorator } from '@storybook/react';
 import { AstroThemeProvider } from '@magnetis/astro-galaxy-core';
+import { addDecorator, configure } from '@storybook/react';
+import React from 'react';
+import styled from 'styled-components';
 
-addDecorator(story => <AstroThemeProvider>{story()}</AstroThemeProvider>);
+const StoryContainer = styled.div`
+  padding: ${props => props.theme.space[2]}px;
+
+  > * {
+    margin: ${props => props.theme.space[1]}px;
+  }
+`;
+
+addDecorator(story => (
+  <AstroThemeProvider>
+    <StoryContainer>{story()}</StoryContainer>
+  </AstroThemeProvider>
+));
 
 // automatically import all files ending in *.story.js
 const componentsContext = require.context('../packages/components', true, /.story\.js$/);

--- a/packages/components/src/Button/index.story.js
+++ b/packages/components/src/Button/index.story.js
@@ -1,23 +1,22 @@
-import React from 'react';
 import { storiesOf } from '@storybook/react';
+import React from 'react';
 import Button from './index.js';
 
-storiesOf('buttons', module)
-  .add('button default', () => <Button>uranus</Button>)
-  .add('primary buttons variants', () => (
-    <React.Fragment>
+storiesOf('buttons|primary buttons', module)
+  .add('default', () => <Button>uranus</Button>)
+  .add('variants', () => (
+    <>
       <Button variant="primary.uranus">uranus</Button>
       <Button variant="primary.earth">earth</Button>
       <Button variant="primary.venus">venus</Button>
       <Button variant="primary.mars">mars</Button>
       <Button disabled>disabled</Button>
-    </React.Fragment>
+    </>
+  ))
+  .add('sizes', () => (
+    <>
+      <Button buttonSize="small">small</Button>
+      <Button buttonSize="medium">medium ~ default</Button>
+      <Button buttonSize="large">large</Button>
+    </>
   ));
-
-storiesOf('button sizes', module).add('primary buttons sizes', () => (
-  <React.Fragment>
-    <Button buttonSize="small">small</Button>
-    <Button buttonSize="medium">medium ~ default</Button>
-    <Button buttonSize="large">large</Button>
-  </React.Fragment>
-));

--- a/packages/components/src/Checkbox/index.story.js
+++ b/packages/components/src/Checkbox/index.story.js
@@ -1,9 +1,9 @@
-import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { CheckboxWrapper, Checkbox, CheckboxShape } from './index.js';
+import React from 'react';
 import Label from '../Label';
+import { Checkbox, CheckboxShape, CheckboxWrapper } from './index.js';
 
-storiesOf('checkbox', module)
+storiesOf('controls & toggles|checkboxes', module)
   .add('default', () => (
     <>
       <CheckboxWrapper>
@@ -20,7 +20,7 @@ storiesOf('checkbox', module)
   ))
   .add('indeterminate', () => (
     <CheckboxWrapper>
-      <Checkbox indeterminate id="checkbox2" />
+      <Checkbox indeterminate id="checkbox2" checked />
       <CheckboxShape />
       <Label htmlFor="checkbox2">Checkbox</Label>
     </CheckboxWrapper>

--- a/packages/components/src/Heading/index.story.js
+++ b/packages/components/src/Heading/index.story.js
@@ -1,8 +1,8 @@
-import React from 'react';
 import { storiesOf } from '@storybook/react';
+import React from 'react';
 import Heading from './index.js';
 
-storiesOf('Heading', module)
+storiesOf('typography|heading', module)
   .add('default', () => <Heading>Astro Galaxy</Heading>)
   .add('colors', () => (
     <>

--- a/packages/components/src/IconButton/index.story.js
+++ b/packages/components/src/IconButton/index.story.js
@@ -1,15 +1,15 @@
-import React from 'react';
-import { storiesOf } from '@storybook/react';
-import IconButton from './index.js';
 import { IconCalendar } from '@magnetis/astro-galaxy-icons';
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+import IconButton from './index.js';
 
-storiesOf('icon buttons', module)
-  .add('icon button default', () => (
+storiesOf('buttons|icon buttons', module)
+  .add('default', () => (
     <IconButton>
       <IconCalendar />
     </IconButton>
   ))
-  .add('primary icon buttons variants', () => (
+  .add('variants', () => (
     <>
       <IconButton variant="primary.uranus" iconlabel>
         <IconCalendar />
@@ -28,18 +28,17 @@ storiesOf('icon buttons', module)
         <IconCalendar />
       </IconButton>
     </>
+  ))
+  .add('sizes', () => (
+    <>
+      <IconButton buttonSize="small">
+        <IconCalendar />
+      </IconButton>
+      <IconButton buttonSize="medium">
+        <IconCalendar />
+      </IconButton>
+      <IconButton buttonSize="large">
+        <IconCalendar />
+      </IconButton>
+    </>
   ));
-
-storiesOf('icon button sizes', module).add('primary icon buttons sizes', () => (
-  <>
-    <IconButton buttonSize="small">
-      <IconCalendar />
-    </IconButton>
-    <IconButton buttonSize="medium">
-      <IconCalendar />
-    </IconButton>
-    <IconButton buttonSize="large">
-      <IconCalendar />
-    </IconButton>
-  </>
-));

--- a/packages/components/src/IconGhostButton/index.story.js
+++ b/packages/components/src/IconGhostButton/index.story.js
@@ -1,15 +1,15 @@
-import React from 'react';
-import { storiesOf } from '@storybook/react';
-import IconGhostButton from './index.js';
 import { IconCalendar } from '@magnetis/astro-galaxy-icons';
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+import IconGhostButton from './index.js';
 
-storiesOf('icon ghost buttons', module)
-  .add('icon ghost button default', () => (
+storiesOf('buttons|ghost icon buttons', module)
+  .add('default', () => (
     <IconGhostButton>
       <IconCalendar />
     </IconGhostButton>
   ))
-  .add('icon ghost buttons variants', () => (
+  .add('variants', () => (
     <>
       <IconGhostButton variant="ghost.uranus" iconlabel>
         <IconCalendar />
@@ -29,7 +29,28 @@ storiesOf('icon ghost buttons', module)
       </IconGhostButton>
     </>
   ))
-  .add('iconlabel ghost buttons', () => (
+  .add('sizes', () => (
+    <>
+      <IconGhostButton buttonSize="small">
+        <IconCalendar />
+      </IconGhostButton>
+      <IconGhostButton buttonSize="medium">
+        <IconCalendar />
+      </IconGhostButton>
+      <IconGhostButton buttonSize="large">
+        <IconCalendar />
+      </IconGhostButton>
+    </>
+  ));
+
+storiesOf('buttons|ghost iconlabel buttons', module)
+  .add('default', () => (
+    <IconGhostButton iconlabel>
+      <IconCalendar />
+      label
+    </IconGhostButton>
+  ))
+  .add('variants', () => (
     <>
       <IconGhostButton variant="ghost.uranus" iconlabel>
         <IconCalendar />
@@ -53,7 +74,7 @@ storiesOf('icon ghost buttons', module)
       </IconGhostButton>
     </>
   ))
-  .add('iconlabelRight ghost buttons', () => (
+  .add('right label', () => (
     <>
       <IconGhostButton variant="ghost.uranus" iconlabel iconlabelRight>
         uranus
@@ -77,17 +98,3 @@ storiesOf('icon ghost buttons', module)
       </IconGhostButton>
     </>
   ));
-
-storiesOf('icon ghost button sizes', module).add('icon ghost buttons sizes', () => (
-  <>
-    <IconGhostButton buttonSize="small">
-      <IconCalendar />
-    </IconGhostButton>
-    <IconGhostButton buttonSize="medium">
-      <IconCalendar />
-    </IconGhostButton>
-    <IconGhostButton buttonSize="large">
-      <IconCalendar />
-    </IconGhostButton>
-  </>
-));

--- a/packages/components/src/IconLinkButton/index.story.js
+++ b/packages/components/src/IconLinkButton/index.story.js
@@ -4,30 +4,31 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 import IconLinkButton from './index.js';
 
-storiesOf('icon link button', module)
+storiesOf('buttons|icon link buttons', module)
   .addParameters({
     backgrounds: [{ name: 'moon 900', value: theme.colors.moon900, default: true }],
   })
   .add('default', () => (
-    <>
-      <IconLinkButton>
-        <IconCalendar />
-        icon link
-      </IconLinkButton>
-
-      <IconLinkButton bold>
-        <IconCalendar />
-        icon link bold
-      </IconLinkButton>
-
-      <IconLinkButton iconlabel iconlabelRight>
-        icon link
-        <IconCalendar />
-      </IconLinkButton>
-
-      <IconLinkButton iconlabel iconlabelRight disabled>
-        icon link
-        <IconCalendar />
-      </IconLinkButton>
-    </>
+    <IconLinkButton>
+      <IconCalendar />
+      icon link
+    </IconLinkButton>
+  ))
+  .add('bold', () => (
+    <IconLinkButton bold>
+      <IconCalendar />
+      icon link
+    </IconLinkButton>
+  ))
+  .add('right label', () => (
+    <IconLinkButton iconlabel iconlabelRight>
+      icon link
+      <IconCalendar />
+    </IconLinkButton>
+  ))
+  .add('disabled', () => (
+    <IconLinkButton disabled>
+      <IconCalendar />
+      icon link
+    </IconLinkButton>
   ));

--- a/packages/components/src/IconOutlineButton/index.story.js
+++ b/packages/components/src/IconOutlineButton/index.story.js
@@ -1,15 +1,15 @@
-import React from 'react';
-import { storiesOf } from '@storybook/react';
-import IconOutlineButton from './index.js';
 import { IconCalendar } from '@magnetis/astro-galaxy-icons';
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+import IconOutlineButton from './index.js';
 
-storiesOf('icon outline buttons', module)
-  .add('icon button default', () => (
+storiesOf('buttons|outline buttons', module)
+  .add('default', () => (
     <IconOutlineButton>
       <IconCalendar />
     </IconOutlineButton>
   ))
-  .add('icon outline buttons variants', () => (
+  .add('variants', () => (
     <>
       <IconOutlineButton variant="outline.uranus">
         <IconCalendar />
@@ -27,24 +27,29 @@ storiesOf('icon outline buttons', module)
         <IconCalendar />
       </IconOutlineButton>
     </>
+  ))
+  .add('sizes', () => (
+    <>
+      <IconOutlineButton buttonSize="small">
+        <IconCalendar />
+      </IconOutlineButton>
+      <IconOutlineButton buttonSize="medium">
+        <IconCalendar />
+      </IconOutlineButton>
+      <IconOutlineButton buttonSize="large">
+        <IconCalendar />
+      </IconOutlineButton>
+    </>
   ));
 
-storiesOf('icon outline button sizes', module).add('icon outline buttons sizes', () => (
-  <>
-    <IconOutlineButton buttonSize="small">
+storiesOf('buttons|outline iconlabel buttons', module)
+  .add('default', () => (
+    <IconOutlineButton iconlabel>
       <IconCalendar />
+      uranus
     </IconOutlineButton>
-    <IconOutlineButton buttonSize="medium">
-      <IconCalendar />
-    </IconOutlineButton>
-    <IconOutlineButton buttonSize="large">
-      <IconCalendar />
-    </IconOutlineButton>
-  </>
-));
-
-storiesOf('iconlabel outline button', module)
-  .add('iconlabel', () => (
+  ))
+  .add('variants', () => (
     <>
       <IconOutlineButton variant="outline.uranus" iconlabel>
         <IconCalendar />
@@ -68,7 +73,7 @@ storiesOf('iconlabel outline button', module)
       </IconOutlineButton>
     </>
   ))
-  .add('iconlabelRight', () => (
+  .add('right label', () => (
     <>
       <IconOutlineButton variant="outline.uranus" iconlabel iconlabelRight>
         uranus
@@ -92,7 +97,7 @@ storiesOf('iconlabel outline button', module)
       </IconOutlineButton>
     </>
   ))
-  .add('iconlabel button sizes', () => (
+  .add('sizes', () => (
     <>
       <IconOutlineButton buttonSize="small" iconlabel>
         <IconCalendar />

--- a/packages/components/src/InputFilePreview/index.story.js
+++ b/packages/components/src/InputFilePreview/index.story.js
@@ -1,15 +1,15 @@
-import React from 'react';
 import { storiesOf } from '@storybook/react';
+import React from 'react';
 import {
   InputFilePreview,
+  InputFilePreviewCloseIcon,
+  InputFilePreviewImage,
   InputFilePreviewItem,
   InputFilePreviewRemoveButton,
   InputFilePreviewText,
-  InputFilePreviewImage,
-  InputFilePreviewCloseIcon,
 } from './index.js';
 
-storiesOf('input file preview', module).add('default', () => (
+storiesOf('inputs|uploaded files preview', module).add('default', () => (
   <>
     <InputFilePreview>
       <InputFilePreviewItem>

--- a/packages/components/src/InputGhost/index.story.js
+++ b/packages/components/src/InputGhost/index.story.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 import InputGhost from './index.js';
 
-storiesOf('input ghost', module)
+storiesOf('inputs|ghost inputs', module)
   .addParameters({
     backgrounds: [
       { name: 'moon 900', value: theme.colors.moon900, default: true },

--- a/packages/components/src/InputMasked/index.story.js
+++ b/packages/components/src/InputMasked/index.story.js
@@ -2,8 +2,8 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 import InputMasked, { maskTypes } from './index.js';
 
-storiesOf('input masked', module)
-  .add('CPF', () => (
+storiesOf('inputs|masked inputs', module)
+  .add('cpf', () => (
     <InputMasked
       inputId="cpfMaskedInput"
       labelId="cpfMaskedLabel"
@@ -11,7 +11,7 @@ storiesOf('input masked', module)
       maskType={maskTypes.cpf}
     />
   ))
-  .add('Currency', () => (
+  .add('currency', () => (
     <InputMasked
       inputId="currencyMaskedInput"
       labelId="currencyMaskedLabel"
@@ -19,7 +19,7 @@ storiesOf('input masked', module)
       maskType={maskTypes.currency}
     />
   ))
-  .add('Date', () => (
+  .add('date', () => (
     <InputMasked
       inputId="dateMaskedInput"
       labelId="dateMaskedLabel"

--- a/packages/components/src/InputText/index.story.js
+++ b/packages/components/src/InputText/index.story.js
@@ -17,7 +17,7 @@ const buildProps = (props = {}) => ({
   ...props,
 });
 
-storiesOf('input text', module)
+storiesOf('inputs|standard text inputs', module)
   .addDecorator(withKnobs)
   .add('default', () => <InputText {...buildProps()} />)
   .add('validated', () => (

--- a/packages/components/src/Label/index.story.js
+++ b/packages/components/src/Label/index.story.js
@@ -1,5 +1,5 @@
-import React from 'react';
 import { storiesOf } from '@storybook/react';
+import React from 'react';
 import Label from './index.js';
 
-storiesOf('label', module).add('label', () => <Label>Label</Label>);
+storiesOf('typography|labels', module).add('default', () => <Label>Label</Label>);

--- a/packages/components/src/Link/index.story.js
+++ b/packages/components/src/Link/index.story.js
@@ -1,8 +1,8 @@
-import React from 'react';
 import { storiesOf } from '@storybook/react';
+import React from 'react';
 import Link from './index.js';
 
-storiesOf('Link', module).add('default', () => (
+storiesOf('buttons|links', module).add('default', () => (
   <>
     <Link>primary font - medium size</Link>
     <br />

--- a/packages/components/src/OutlineButton/index.story.js
+++ b/packages/components/src/OutlineButton/index.story.js
@@ -1,10 +1,10 @@
-import React from 'react';
 import { storiesOf } from '@storybook/react';
+import React from 'react';
 import OutlineButton from './index.js';
 
-storiesOf('outline buttons', module)
-  .add('button default', () => <OutlineButton>uranus</OutlineButton>)
-  .add('outline buttons variants', () => (
+storiesOf('buttons|outline buttons', module)
+  .add('default', () => <OutlineButton>uranus</OutlineButton>)
+  .add('variants', () => (
     <React.Fragment>
       <OutlineButton variant="outline.uranus">uranus</OutlineButton>
       <OutlineButton variant="outline.earth">earth</OutlineButton>
@@ -12,12 +12,11 @@ storiesOf('outline buttons', module)
       <OutlineButton variant="outline.mars">mars</OutlineButton>
       <OutlineButton disabled>disabled</OutlineButton>
     </React.Fragment>
+  ))
+  .add('sizes', () => (
+    <React.Fragment>
+      <OutlineButton buttonSize="small">small</OutlineButton>
+      <OutlineButton buttonSize="medium">medium ~ default</OutlineButton>
+      <OutlineButton buttonSize="large">large</OutlineButton>
+    </React.Fragment>
   ));
-
-storiesOf('outline button sizes', module).add('outline buttons sizes', () => (
-  <React.Fragment>
-    <OutlineButton buttonSize="small">small</OutlineButton>
-    <OutlineButton buttonSize="medium">medium ~ default</OutlineButton>
-    <OutlineButton buttonSize="large">large</OutlineButton>
-  </React.Fragment>
-));

--- a/packages/components/src/Radio/index.story.js
+++ b/packages/components/src/Radio/index.story.js
@@ -1,10 +1,10 @@
-import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { RadioWrapper, Radio, RadioShape } from './index.js';
+import React from 'react';
 import Label from '../Label';
+import { Radio, RadioShape, RadioWrapper } from './index.js';
 
-storiesOf('radio', module)
-  .add('radio', () => (
+storiesOf('controls & toggles|radio buttons', module)
+  .add('default', () => (
     <>
       <RadioWrapper>
         <Radio id="radio1" name="radiogroup1" />
@@ -18,7 +18,7 @@ storiesOf('radio', module)
       </RadioWrapper>
     </>
   ))
-  .add('radio with center align', () => (
+  .add('long label', () => (
     <>
       <RadioWrapper>
         <Radio id="radio4" name="radiogroup3" />
@@ -38,7 +38,7 @@ storiesOf('radio', module)
       </RadioWrapper>
     </>
   ))
-  .add('radio disabled', () => (
+  .add('disabled', () => (
     <RadioWrapper>
       <Radio disabled id="radio3" name="radiogroup2" />
       <RadioShape />

--- a/packages/components/src/Slider/index.story.js
+++ b/packages/components/src/Slider/index.story.js
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
+import React, { useState } from 'react';
 import Slider from './index.js';
 
-storiesOf('Slider', module)
+storiesOf('controls & toggles|sliders', module)
   .add('default', () => {
     const SliderDefault = props => {
       const [value, setValue] = useState(50);
@@ -45,7 +45,6 @@ storiesOf('Slider', module)
     };
     return <SliderFullFill />;
   })
-
   .add('only label', () => {
     const SliderOnlyLabel = props => {
       const [value, setValue] = useState(25);

--- a/packages/components/src/Tab/index.story.js
+++ b/packages/components/src/Tab/index.story.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import { Heading, Text } from '@magnetis/astro-galaxy-components';
+import { IconCalendar, IconMoneyBag, IconPencil } from '@magnetis/astro-galaxy-icons';
 import { storiesOf } from '@storybook/react';
-import { Text, Heading } from '@magnetis/astro-galaxy-components';
-import { IconPencil, IconMoneyBag, IconCalendar } from '@magnetis/astro-galaxy-icons';
-import { Tab, TabItem, TabLabel, TabContent } from './index.js';
+import React from 'react';
+import { Tab, TabContent, TabItem, TabLabel } from './index.js';
 
-storiesOf('Tab', module)
+storiesOf('controls & toggles|tabs', module)
   .add('default', () => (
     <Tab>
       <TabItem id="tab1" name="tabs" defaultChecked />

--- a/packages/components/src/Tabbed/index.story.js
+++ b/packages/components/src/Tabbed/index.story.js
@@ -4,7 +4,7 @@ import React from 'react';
 import Tabbed, { Section, Tab } from '.';
 import Text from '../Text';
 
-storiesOf('tabbed', module).add('default', () => (
+storiesOf('controls & toggles|tabbeds', module).add('default', () => (
   <Tabbed
     tabs={
       <>

--- a/packages/components/src/Table/index.story.js
+++ b/packages/components/src/Table/index.story.js
@@ -67,7 +67,7 @@ const DemoTable = props => (
   </Table>
 );
 
-storiesOf('table', module)
+storiesOf('tables|tables', module)
   .addDecorator(withKnobs)
   .add('default', () => <DemoTable />, backgroundSelector(false))
   .add('dark mode', () => <DemoTable darkMode />, backgroundSelector(true));

--- a/packages/components/src/Text/index.story.js
+++ b/packages/components/src/Text/index.story.js
@@ -1,8 +1,8 @@
-import React from 'react';
 import { storiesOf } from '@storybook/react';
+import React from 'react';
 import Text from './index.js';
 
-storiesOf('Text', module)
+storiesOf('typography|texts', module)
   .add('primary', () => <Text>Astro Galaxy</Text>)
   .add('secondary', () => <Text font="secondary">Astro Galaxy</Text>)
   .add('colors', () => (

--- a/packages/components/src/TextArea/index.story.js
+++ b/packages/components/src/TextArea/index.story.js
@@ -1,19 +1,17 @@
-import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { TextAreaWrapper, TextArea, TextAreaLabel } from './index.js';
+import React from 'react';
+import { TextArea, TextAreaLabel, TextAreaWrapper } from './index.js';
 
-const TextAreaSample = () => (
-  <>
+storiesOf('inputs|textarea inputs', module)
+  .add('default', () => (
     <TextAreaWrapper>
       <TextArea />
       <TextAreaLabel>Label</TextAreaLabel>
     </TextAreaWrapper>
-
+  ))
+  .add('disabled', () => (
     <TextAreaWrapper>
       <TextArea disabled />
       <TextAreaLabel>Label</TextAreaLabel>
     </TextAreaWrapper>
-  </>
-);
-
-storiesOf('TextArea', module).add('default', () => <TextAreaSample />);
+  ));

--- a/packages/components/src/Toggle/index.story.js
+++ b/packages/components/src/Toggle/index.story.js
@@ -1,16 +1,22 @@
-import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
+import React, { useState } from 'react';
 import Toggle from './index.js';
 
-const ToggleSample = () => {
+const ToggleSample = ({ disabled }) => {
   const [isToggled, setToggle] = useState(false);
 
   return (
     <>
-      <Toggle label="resgate total" isToggled={isToggled} onClick={() => setToggle(!isToggled)} />
-      <Toggle label="disabled" disabled />
+      <Toggle
+        label="default"
+        isToggled={isToggled}
+        onClick={() => setToggle(!isToggled)}
+        disabled={disabled}
+      />
     </>
   );
 };
 
-storiesOf('Toggle', module).add('default', () => <ToggleSample />);
+storiesOf('controls & toggles|toggles', module)
+  .add('default', () => <ToggleSample />)
+  .add('disabled', () => <ToggleSample disabled />);

--- a/packages/icons/index.story.js
+++ b/packages/icons/index.story.js
@@ -1,6 +1,6 @@
-import React from 'react';
 import { storiesOf } from '@storybook/react';
 import map from 'lodash/map';
+import React from 'react';
 import * as icons from './lib/index.es';
 
 /**
@@ -8,9 +8,9 @@ import * as icons from './lib/index.es';
   small = 24
   medium = 32
   large = 40
-  
+
   - To apply spacing (margin-left and margin-right) we shall use ml (marginLeft) and mr (marginRight) with the following values:
-  
+
   8px = 1 (space array index 1)
 **/
 const Story = () => {
@@ -19,4 +19,4 @@ const Story = () => {
   ));
 };
 
-storiesOf('iconography', module).add('Astro icons', () => <Story />);
+storiesOf('iconography|icons', module).add('all', () => <Story />);


### PR DESCRIPTION
# What

This PR organizes the Storybook menu options and adds spaces in the demo area.

# Why

* To fit the mental model of the Design team
* To space the components samples in the demo area

and...

[![OCD](https://img.youtube.com/vi/tnzz-eFmKaw/0.jpg)](https://www.youtube.com/watch?v=tnzz-eFmKaw)

([YouTube](https://www.youtube.com/watch?v=tnzz-eFmKaw))

# How

* Create sections on the menu
* Rename and reorganize menu options
* Adjust component demo sections

# Sample

## Menu

### Before

| Menu tree | |
| --- | --- |
| <img width="205" alt="Captura de Tela 2020-04-02 às 11 13 10" src="https://user-images.githubusercontent.com/1002072/78259416-0dffa280-74d3-11ea-989d-225fc9fabf85.png"> | <img width="201" alt="Captura de Tela 2020-04-02 às 11 13 34" src="https://user-images.githubusercontent.com/1002072/78259429-12c45680-74d3-11ea-9469-a26a8614b6d3.png"> |

### After

| Menu tree | |
| --- | --- |
| <img width="204" alt="Captura de Tela 2020-04-02 às 09 01 39" src="https://user-images.githubusercontent.com/1002072/78257919-df80c800-74d0-11ea-94f3-398e4cf1d86a.png"> | <img width="206" alt="Captura de Tela 2020-04-02 às 11 09 45" src="https://user-images.githubusercontent.com/1002072/78259027-7e59f400-74d2-11ea-99b2-fb09cf1e8e73.png"> |

## Spacing

### Before

<img width="1276" alt="Captura de Tela 2020-04-02 às 11 22 45" src="https://user-images.githubusercontent.com/1002072/78260401-4d7abe80-74d4-11ea-8024-117887784028.png">

### After

<img width="1276" alt="Captura de Tela 2020-04-02 às 10 33 55" src="https://user-images.githubusercontent.com/1002072/78260148-0391d880-74d4-11ea-8f65-765d5f1a25ef.png">

# Refs

* [Astro vanilla docs](http://astro.magnetis.com.br/)
* [Clubhouse card](https://app.clubhouse.io/magnetis/story/33954/criar-espa%C3%A7amento-global-e-normatizar-op%C3%A7%C3%B5es-de-menu-no-storybook)