### PR TITLE
Add control input component

### DIFF
--- a/packages/components/src/IconGhostButton/index.js
+++ b/packages/components/src/IconGhostButton/index.js
@@ -15,6 +15,9 @@ const iconColor = props => ({
   'ghost.mars': `
     color: ${props.theme.colors.mars500};
   `,
+  'ghost.moon': `
+    color: ${props.theme.colors.moon500};
+  `,
 });
 
 const buttonHoverStyles = props => ({
@@ -30,6 +33,9 @@ const buttonHoverStyles = props => ({
   'ghost.mars': `
     color: ${props.theme.colors.mars400};
   `,
+  'ghost.moon': `
+    color: ${props.theme.colors.moon400};
+  `,
 });
 
 const buttonActiveStyles = props => ({
@@ -44,6 +50,9 @@ const buttonActiveStyles = props => ({
   `,
   'ghost.mars': `
     color: ${props.theme.colors.mars600};
+  `,
+  'ghost.moon': `
+    color: ${props.theme.colors.moon600};
   `,
 });
 
@@ -84,7 +93,13 @@ const IconGhostButton = styled(IconButton)`
 IconGhostButton.displayName = 'IconGhostButton';
 
 IconGhostButton.propTypes = {
-  variant: PropTypes.oneOf(['ghost.uranus', 'ghost.earth', 'ghost.venus', 'ghost.mars']),
+  variant: PropTypes.oneOf([
+    'ghost.uranus',
+    'ghost.earth',
+    'ghost.venus',
+    'ghost.mars',
+    'ghost.moon',
+  ]),
   buttonSize: PropTypes.oneOf(['small', 'medium', 'large']),
   iconlabel: PropTypes.bool,
 };

--- a/packages/components/src/InputControl/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/components/src/InputControl/__tests__/__snapshots__/index.test.js.snap
@@ -233,8 +233,11 @@ exports[`InputControl renders correctly 1`] = `
     className="c4"
   >
     <button
+      aria-label="decrement"
       className="c5"
       display="inline-block"
+      onClick={[Function]}
+      title="decrement"
     >
       <svg
         className="c6"
@@ -254,8 +257,11 @@ exports[`InputControl renders correctly 1`] = `
       </svg>
     </button>
     <button
+      aria-label="increment"
       className="c5"
       display="inline-block"
+      onClick={[Function]}
+      title="increment"
     >
       <svg
         className="c6"

--- a/packages/components/src/InputControl/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/components/src/InputControl/__tests__/__snapshots__/index.test.js.snap
@@ -233,11 +233,9 @@ exports[`InputControl renders correctly 1`] = `
     className="c4"
   >
     <button
-      aria-label="decrement"
       className="c5"
       display="inline-block"
       onClick={[Function]}
-      title="decrement"
     >
       <svg
         className="c6"
@@ -257,11 +255,9 @@ exports[`InputControl renders correctly 1`] = `
       </svg>
     </button>
     <button
-      aria-label="increment"
       className="c5"
       display="inline-block"
       onClick={[Function]}
-      title="increment"
     >
       <svg
         className="c6"

--- a/packages/components/src/InputControl/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/components/src/InputControl/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,280 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InputControl renders correctly 1`] = `
+.c6 {
+  fill: currentcolor;
+  color: #32383c;
+}
+
+.c5 {
+  cursor: pointer;
+  white-space: nowrap;
+  text-align: center;
+  -webkit-transition: all 0.3s ease;
+  transition: all 0.3s ease;
+  overflow: hidden;
+  border-width: 2px;
+  border-style: solid;
+  font: normal normal 600 normal 16px/1.5 Poppins,sans-serif;
+  display: inline-block;
+  background-color: transparent;
+  color: #597183;
+  border-color: transparent;
+  padding: 8px 38px;
+  font-size: 16px;
+  line-height: 28px;
+  border-radius: 24px;
+  padding: 8px 6px;
+}
+
+.c5:disabled {
+  cursor: not-allowed;
+  background-color: #e9eef2;
+  border-color: #e9eef2;
+  color: #ffffff;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5 svg {
+  -webkit-transition: all 0.3s ease;
+  transition: all 0.3s ease;
+  vertical-align: middle;
+  margin: -4px 0 -3px;
+  width: 32px;
+  height: 32px;
+}
+
+.c5 svg {
+  color: #597183;
+}
+
+.c5:disabled {
+  background-color: transparent;
+  border-color: transparent;
+  color: #e9eef2;
+}
+
+.c5:disabled svg {
+  color: #e9eef2;
+}
+
+.c5:hover:not(:disabled) svg,
+.c5:focus:not(:disabled) svg {
+  color: #8296a4;
+}
+
+.c5:hover:not(:disabled),
+.c5:focus:not(:disabled) {
+  background-color: #f6f7f8;
+  border-color: #f6f7f8;
+  color: #8296a4;
+}
+
+.c5:active:not(:disabled) {
+  background-color: #e9eef2;
+  border-color: #e9eef2;
+  color: #495c69;
+}
+
+.c1 {
+  border: 0;
+  padding: 0;
+  position: relative;
+}
+
+.c3 {
+  font: normal normal 400 normal 16px/1.5 Lato,sans-serif;
+  height: 4em;
+  padding: 1em;
+  pointer-events: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  color: #8296a4;
+  font-size: 16px;
+}
+
+.c2 {
+  background-color: #ffffff;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 8px;
+  color: #32383c;
+  font: normal normal 400 normal 16px/1.5 Lato,sans-serif;
+  padding: 25px 16px 5px;
+  position: relative;
+  width: 100%;
+  border-color: #597183;
+}
+
+.c2::-webkit-input-placeholder {
+  color: transparent;
+}
+
+.c2::-moz-placeholder {
+  color: transparent;
+}
+
+.c2:-ms-input-placeholder {
+  color: transparent;
+}
+
+.c2::placeholder {
+  color: transparent;
+}
+
+.c2:focus::-webkit-input-placeholder,
+.c2.--no-animate::-webkit-input-placeholder {
+  color: #afbec9;
+}
+
+.c2:focus::-moz-placeholder,
+.c2.--no-animate::-moz-placeholder {
+  color: #afbec9;
+}
+
+.c2:focus:-ms-input-placeholder,
+.c2.--no-animate:-ms-input-placeholder {
+  color: #afbec9;
+}
+
+.c2:focus::placeholder,
+.c2.--no-animate::placeholder {
+  color: #afbec9;
+}
+
+.c2:focus {
+  outline: none;
+  border-color: #597183;
+}
+
+.c2:focus + label {
+  color: #159ce4;
+}
+
+.c2:focus,
+.c2:not(:placeholder-shown),
+.c2.--no-animate {
+  border-color: #159ce4;
+}
+
+.c2:focus + label,
+.c2:not(:placeholder-shown) + label,
+.c2.--no-animate + label {
+  font-weight: 700;
+  -webkit-transform: translate(3px,-6px) scale(0.8);
+  -ms-transform: translate(3px,-6px) scale(0.8);
+  transform: translate(3px,-6px) scale(0.8);
+}
+
+.c2.--no-animate {
+  border-color: #597183;
+}
+
+.c2.--no-animate:focus {
+  border-color: #159ce4;
+}
+
+.c2 + label {
+  left: 0;
+  position: absolute;
+  top: 0;
+  -webkit-transition: -webkit-transform 0.25s,opacity 0.25s ease-in-out;
+  -webkit-transition: transform 0.25s,opacity 0.25s ease-in-out;
+  transition: transform 0.25s,opacity 0.25s ease-in-out;
+  -webkit-transform-origin: 0 0;
+  -ms-transform-origin: 0 0;
+  transform-origin: 0 0;
+}
+
+.c0 {
+  position: relative;
+}
+
+.c4 {
+  position: absolute;
+  right: 8px;
+  top: 5%;
+}
+
+<div
+  className="c0"
+>
+  <fieldset
+    className="c1"
+  >
+    <input
+      aria-labelledby="controlInputLabel"
+      className="c2  --no-animate"
+      id="controlInputId"
+      inputMode="numeric"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onMouseUp={[Function]}
+      placeholder="0,00"
+      type="text"
+      value=""
+    />
+    <label
+      className="c3"
+      htmlFor="controlInputId"
+      id="controlInputLabel"
+    >
+      Standard
+    </label>
+  </fieldset>
+  <div
+    className="c4"
+  >
+    <button
+      className="c5"
+      display="inline-block"
+    >
+      <svg
+        className="c6"
+        color="moon900"
+        height={24}
+        viewBox="0 0 32 32"
+        width={24}
+      >
+        <g
+          id="icons/support/less-circle"
+        >
+          <path
+            d="M16.5 29C9.596 29 4 23.404 4 16.5S9.596 4 16.5 4 29 9.596 29 16.5 23.404 29 16.5 29zm0-1.786c5.917 0 10.714-4.797 10.714-10.714 0-5.917-4.797-10.714-10.714-10.714-5.917 0-10.714 4.797-10.714 10.714 0 5.917 4.797 10.714 10.714 10.714zM11.143 16.5h10.714-10.714zm-.893 0c0-.493.4-.893.893-.893h10.714a.893.893 0 0 1 0 1.786H11.143a.893.893 0 0 1-.893-.893z"
+            id="Combined-Shape"
+          />
+        </g>
+      </svg>
+    </button>
+    <button
+      className="c5"
+      display="inline-block"
+    >
+      <svg
+        className="c6"
+        color="moon900"
+        height={24}
+        viewBox="0 0 32 32"
+        width={24}
+      >
+        <g
+          id="icons/support/more-circle"
+        >
+          <path
+            d="M16 15.013l3.687-3.687a.77.77 0 0 1 1.088 1.088L17.088 16.1l3.687 3.686a.77.77 0 0 1-1.088 1.088L16 17.188l-3.687 3.687a.77.77 0 0 1-1.088-1.088l3.687-3.686-3.687-3.687a.77.77 0 0 1 1.088-1.088L16 15.013zM28.5 16c0 6.904-5.596 12.5-12.5 12.5S3.5 22.904 3.5 16 9.096 3.5 16 3.5 28.5 9.096 28.5 16zm-2 0c0-5.799-4.701-10.5-10.5-10.5S5.5 10.201 5.5 16 10.201 26.5 16 26.5 26.5 21.799 26.5 16z"
+            id="Mask"
+            transform="rotate(-45 16 16)"
+          />
+        </g>
+      </svg>
+    </button>
+  </div>
+</div>
+`;

--- a/packages/components/src/InputControl/__tests__/index.test.js
+++ b/packages/components/src/InputControl/__tests__/index.test.js
@@ -4,7 +4,14 @@ import InputControl from '../';
 describe('InputControl', () => {
   it('renders correctly', () => {
     const json = rendererCreateWithTheme(
-      <InputControl inputId="controlInputId" labelId="controlInputLabel" />
+      <InputControl
+        inputId="controlInputId"
+        labelId="controlInputLabel"
+        onIncrement={() => {}}
+        onDecrement={() => {}}
+        incrementLabel="increment"
+        decrementLabel="decrement"
+      />
     ).toJSON();
 
     expect(json).toMatchSnapshot();

--- a/packages/components/src/InputControl/__tests__/index.test.js
+++ b/packages/components/src/InputControl/__tests__/index.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import InputControl from '../';
+
+describe('InputControl', () => {
+  it('renders correctly', () => {
+    const json = rendererCreateWithTheme(
+      <InputControl inputId="controlInputId" labelId="controlInputLabel" />
+    ).toJSON();
+
+    expect(json).toMatchSnapshot();
+  });
+});

--- a/packages/components/src/InputControl/index.js
+++ b/packages/components/src/InputControl/index.js
@@ -21,6 +21,7 @@ const InputControl = ({
   onDecrement,
   incrementLabel,
   decrementLabel,
+  buttonProps,
   ...inputProps
 }) => {
   const buttonSize =
@@ -43,18 +44,16 @@ const InputControl = ({
           onClick={onDecrement}
           buttonSize={buttonSize}
           variant={buttonVariant}
-          aria-label={decrementLabel}
-          title={decrementLabel}
-          disabled={inputProps.disabled}>
+          disabled={inputProps.disabled}
+          {...buttonProps.decrementButtonProps}>
           <IconCircleLess />
         </IconGhostButton>
         <IconGhostButton
           onClick={onIncrement}
           buttonSize={buttonSize}
           variant={buttonVariant}
-          aria-label={incrementLabel}
-          title={incrementLabel}
-          disabled={inputProps.disabled}>
+          disabled={inputProps.disabled}
+          {...buttonProps.incrementButtonProps}>
           <IconCircleMore />
         </IconGhostButton>
       </InputControlButtons>
@@ -64,11 +63,20 @@ const InputControl = ({
 
 InputControl.displayName = 'InputControl';
 
+InputControl.defaultProps = {
+  buttonProps: {
+    incrementButtonProps: {},
+    decrementButtonProps: {},
+  },
+};
+
 InputControl.propTypes = {
   onIncrement: PropTypes.func.isRequired,
   onDecrement: PropTypes.func.isRequired,
-  incrementLabel: PropTypes.string.isRequired,
-  decrementLabel: PropTypes.string.isRequired,
+  buttonProps: PropTypes.shape({
+    incrementButtonProps: PropTypes.object,
+    decrementButtonProps: PropTypes.object,
+  }),
   ...InputMasked.propTypes,
 };
 export default InputControl;

--- a/packages/components/src/InputControl/index.js
+++ b/packages/components/src/InputControl/index.js
@@ -1,0 +1,62 @@
+import { IconCircleLess, IconCircleMore } from '@magnetis/astro-galaxy-icons';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+import IconGhostButton from '../IconGhostButton';
+import InputMasked, { maskTypes } from '../InputMasked';
+import { inputSizes } from '../InputText';
+
+const InputControlContainer = styled.div`
+  position: relative;
+`;
+
+const InputControlButtons = styled.div`
+  position: absolute;
+  right: ${props => props.theme.space[1]}px;
+  top: 5%;
+`;
+
+const InputControl = ({ onIncrement, onDecrement, ...inputProps }) => {
+  const buttonSize =
+    inputProps.inputSize === inputSizes.large ? inputSizes.large : inputSizes.medium;
+  let buttonVariant = 'ghost.moon';
+
+  if (inputProps.isValidated) {
+    buttonVariant = 'ghost.earth';
+  }
+
+  if (inputProps.isInvalid) {
+    buttonVariant = 'ghost.mars';
+  }
+
+  return (
+    <InputControlContainer>
+      <InputMasked maskType={maskTypes.currency} {...inputProps} displayValidationIcon={false} />
+      <InputControlButtons>
+        <IconGhostButton
+          onClick={onDecrement}
+          buttonSize={buttonSize}
+          variant={buttonVariant}
+          disabled={inputProps.disabled}>
+          <IconCircleLess />
+        </IconGhostButton>
+        <IconGhostButton
+          onClick={onIncrement}
+          buttonSize={buttonSize}
+          variant={buttonVariant}
+          disabled={inputProps.disabled}>
+          <IconCircleMore />
+        </IconGhostButton>
+      </InputControlButtons>
+    </InputControlContainer>
+  );
+};
+
+InputControl.displayName = 'InputControl';
+
+InputControl.propTypes = {
+  onIncrement: PropTypes.func,
+  onDecrement: PropTypes.func,
+  ...InputMasked.propTypes,
+};
+export default InputControl;

--- a/packages/components/src/InputControl/index.js
+++ b/packages/components/src/InputControl/index.js
@@ -16,7 +16,13 @@ const InputControlButtons = styled.div`
   top: 5%;
 `;
 
-const InputControl = ({ onIncrement, onDecrement, ...inputProps }) => {
+const InputControl = ({
+  onIncrement,
+  onDecrement,
+  incrementLabel,
+  decrementLabel,
+  ...inputProps
+}) => {
   const buttonSize =
     inputProps.inputSize === inputSizes.large ? inputSizes.large : inputSizes.medium;
   let buttonVariant = 'ghost.moon';
@@ -37,6 +43,8 @@ const InputControl = ({ onIncrement, onDecrement, ...inputProps }) => {
           onClick={onDecrement}
           buttonSize={buttonSize}
           variant={buttonVariant}
+          aria-label={decrementLabel}
+          title={decrementLabel}
           disabled={inputProps.disabled}>
           <IconCircleLess />
         </IconGhostButton>
@@ -44,6 +52,8 @@ const InputControl = ({ onIncrement, onDecrement, ...inputProps }) => {
           onClick={onIncrement}
           buttonSize={buttonSize}
           variant={buttonVariant}
+          aria-label={incrementLabel}
+          title={incrementLabel}
           disabled={inputProps.disabled}>
           <IconCircleMore />
         </IconGhostButton>
@@ -55,8 +65,10 @@ const InputControl = ({ onIncrement, onDecrement, ...inputProps }) => {
 InputControl.displayName = 'InputControl';
 
 InputControl.propTypes = {
-  onIncrement: PropTypes.func,
-  onDecrement: PropTypes.func,
+  onIncrement: PropTypes.func.isRequired,
+  onDecrement: PropTypes.func.isRequired,
+  incrementLabel: PropTypes.string.isRequired,
+  decrementLabel: PropTypes.string.isRequired,
   ...InputMasked.propTypes,
 };
 export default InputControl;

--- a/packages/components/src/InputControl/index.story.js
+++ b/packages/components/src/InputControl/index.story.js
@@ -1,0 +1,34 @@
+import { storiesOf } from '@storybook/react';
+import React, { useState } from 'react';
+import InputControl from '../InputControl';
+import { inputSizes } from '../InputText';
+
+const InputControlSample = ({ ...props }) => {
+  const [value, setValue] = useState(0);
+  const step = 100;
+
+  const handleValue = step => setValue(isNaN(value) ? 0 : parseInt(value, 10) + step);
+
+  return (
+    <InputControl
+      inputId="controlInputId"
+      labelId="controlInputLabel"
+      labelText="Control input"
+      onIncrement={() => handleValue(+step)}
+      onDecrement={() => handleValue(-step)}
+      onChange={event => setValue(event.target.value)}
+      thousandSeparator=""
+      placeholder="0"
+      decimalScale={0}
+      value={value}
+      {...props}
+    />
+  );
+};
+
+storiesOf('inputs|control inputs', module)
+  .add('default', () => <InputControlSample />)
+  .add('validated', () => <InputControlSample isValidated />)
+  .add('invalid', () => <InputControlSample isInvalid errorMessage="Invalid data" />)
+  .add('disabled', () => <InputControlSample disabled={true} />)
+  .add('large', () => <InputControlSample inputSize={inputSizes.large} />);

--- a/packages/components/src/InputControl/index.story.js
+++ b/packages/components/src/InputControl/index.story.js
@@ -6,6 +6,8 @@ import { inputSizes } from '../InputText';
 const InputControlSample = ({ ...props }) => {
   const [value, setValue] = useState(0);
   const step = 100;
+  const incrementLabel = 'increment';
+  const decrementLabel = 'decrement';
 
   const handleValue = step => setValue(isNaN(value) ? 0 : parseInt(value, 10) + step);
 
@@ -16,8 +18,16 @@ const InputControlSample = ({ ...props }) => {
       labelText="Control input"
       onIncrement={() => handleValue(+step)}
       onDecrement={() => handleValue(-step)}
-      incrementLabel="increment"
-      decrementLabel="decrement"
+      buttonProps={{
+        incrementButtonProps: {
+          'aria-label': incrementLabel,
+          title: incrementLabel,
+        },
+        decrementButtonProps: {
+          'aria-label': decrementLabel,
+          title: decrementLabel,
+        },
+      }}
       onChange={event => setValue(event.target.value)}
       thousandSeparator=""
       placeholder="0"

--- a/packages/components/src/InputControl/index.story.js
+++ b/packages/components/src/InputControl/index.story.js
@@ -16,6 +16,8 @@ const InputControlSample = ({ ...props }) => {
       labelText="Control input"
       onIncrement={() => handleValue(+step)}
       onDecrement={() => handleValue(-step)}
+      incrementLabel="increment"
+      decrementLabel="decrement"
       onChange={event => setValue(event.target.value)}
       thousandSeparator=""
       placeholder="0"

--- a/packages/components/src/InputGhost/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/components/src/InputGhost/__tests__/__snapshots__/index.test.js.snap
@@ -93,6 +93,14 @@ exports[`InputGhost renders correctly 1`] = `
   transform: translate(3px,-6px) scale(0.8);
 }
 
+.c1.--no-animate {
+  border-color: #597183;
+}
+
+.c1.--no-animate:focus {
+  border-color: #159ce4;
+}
+
 .c1 + label {
   left: 0;
   position: absolute;

--- a/packages/components/src/InputMasked/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/components/src/InputMasked/__tests__/__snapshots__/index.test.js.snap
@@ -93,6 +93,14 @@ exports[`InputMasked renders CPF masked input 1`] = `
   transform: translate(3px,-6px) scale(0.8);
 }
 
+.c1.--no-animate {
+  border-color: #597183;
+}
+
+.c1.--no-animate:focus {
+  border-color: #159ce4;
+}
+
 .c1 + label {
   left: 0;
   position: absolute;
@@ -139,6 +147,11 @@ exports[`InputMasked renders CPF masked input 1`] = `
             "backgroundColor": "transparent",
             "borderColor": "transparent",
             "color": "#d45459",
+          },
+          "moon": Object {
+            "backgroundColor": "transparent",
+            "borderColor": "transparent",
+            "color": "#597183",
           },
           "uranus": Object {
             "backgroundColor": "transparent",
@@ -375,6 +388,11 @@ exports[`InputMasked renders CPF masked input 1`] = `
               "borderColor": "transparent",
               "color": "#d45459",
             },
+            "moon": Object {
+              "backgroundColor": "transparent",
+              "borderColor": "transparent",
+              "color": "#597183",
+            },
             "uranus": Object {
               "backgroundColor": "transparent",
               "borderColor": "transparent",
@@ -579,6 +597,8 @@ exports[`InputMasked renders CPF masked input 1`] = `
     <InputMasked
       className=""
       decimalScale={2}
+      decimalSeparator=","
+      displayValidationIcon={true}
       inputId="inputId"
       inputSize="medium"
       isInvalid={false}
@@ -595,6 +615,7 @@ exports[`InputMasked renders CPF masked input 1`] = `
         }
       }
       noAnimate={true}
+      thousandSeparator="."
     >
       <InputMask
         alwaysShowMask={false}
@@ -609,6 +630,7 @@ exports[`InputMasked renders CPF masked input 1`] = `
         >
           <InputText
             className=""
+            displayValidationIcon={true}
             inputId="inputId"
             inputSize="medium"
             isInvalid={false}
@@ -702,7 +724,11 @@ exports[`InputMasked renders CPF masked input 1`] = `
                               [Function],
                               ";}",
                               [Function],
-                              ";}& + label{left:0;position:absolute;top:0;transition:transform 0.25s,opacity 0.25s ease-in-out;transform-origin:0 0;}",
+                              ";}&.--no-animate{",
+                              [Function],
+                              ";&:focus{",
+                              [Function],
+                              ";}}& + label{left:0;position:absolute;top:0;transition:transform 0.25s,opacity 0.25s ease-in-out;transform-origin:0 0;}",
                             ],
                           },
                           "displayName": "InputText__InputField",
@@ -896,6 +922,14 @@ exports[`InputMasked renders currency masked input 1`] = `
   transform: translate(3px,-6px) scale(0.8);
 }
 
+.c1.--no-animate {
+  border-color: #597183;
+}
+
+.c1.--no-animate:focus {
+  border-color: #159ce4;
+}
+
 .c1 + label {
   left: 0;
   position: absolute;
@@ -942,6 +976,11 @@ exports[`InputMasked renders currency masked input 1`] = `
             "backgroundColor": "transparent",
             "borderColor": "transparent",
             "color": "#d45459",
+          },
+          "moon": Object {
+            "backgroundColor": "transparent",
+            "borderColor": "transparent",
+            "color": "#597183",
           },
           "uranus": Object {
             "backgroundColor": "transparent",
@@ -1178,6 +1217,11 @@ exports[`InputMasked renders currency masked input 1`] = `
               "borderColor": "transparent",
               "color": "#d45459",
             },
+            "moon": Object {
+              "backgroundColor": "transparent",
+              "borderColor": "transparent",
+              "color": "#597183",
+            },
             "uranus": Object {
               "backgroundColor": "transparent",
               "borderColor": "transparent",
@@ -1382,6 +1426,8 @@ exports[`InputMasked renders currency masked input 1`] = `
     <InputMasked
       className=""
       decimalScale={2}
+      decimalSeparator=","
+      displayValidationIcon={true}
       inputId="inputId"
       inputSize="medium"
       isInvalid={false}
@@ -1398,17 +1444,21 @@ exports[`InputMasked renders currency masked input 1`] = `
         }
       }
       noAnimate={true}
+      thousandSeparator="."
     >
       <NumberFormat
         allowEmptyFormatting={false}
         allowLeadingZeros={false}
         allowNegative={true}
+        className=""
         customInput={[Function]}
         decimalScale={2}
         decimalSeparator=","
         displayType="input"
+        displayValidationIcon={true}
         fixedDecimalScale={false}
         inputId="inputId"
+        inputSize="medium"
         isAllowed={[Function]}
         isInvalid={false}
         isNumericString={false}
@@ -1432,6 +1482,7 @@ exports[`InputMasked renders currency masked input 1`] = `
       >
         <InputText
           className=""
+          displayValidationIcon={true}
           inputId="inputId"
           inputMode="numeric"
           inputSize="medium"
@@ -1532,7 +1583,11 @@ exports[`InputMasked renders currency masked input 1`] = `
                             [Function],
                             ";}",
                             [Function],
-                            ";}& + label{left:0;position:absolute;top:0;transition:transform 0.25s,opacity 0.25s ease-in-out;transform-origin:0 0;}",
+                            ";}&.--no-animate{",
+                            [Function],
+                            ";&:focus{",
+                            [Function],
+                            ";}}& + label{left:0;position:absolute;top:0;transition:transform 0.25s,opacity 0.25s ease-in-out;transform-origin:0 0;}",
                           ],
                         },
                         "displayName": "InputText__InputField",
@@ -1731,6 +1786,14 @@ exports[`InputMasked renders date masked input 1`] = `
   transform: translate(3px,-6px) scale(0.8);
 }
 
+.c1.--no-animate {
+  border-color: #597183;
+}
+
+.c1.--no-animate:focus {
+  border-color: #159ce4;
+}
+
 .c1 + label {
   left: 0;
   position: absolute;
@@ -1777,6 +1840,11 @@ exports[`InputMasked renders date masked input 1`] = `
             "backgroundColor": "transparent",
             "borderColor": "transparent",
             "color": "#d45459",
+          },
+          "moon": Object {
+            "backgroundColor": "transparent",
+            "borderColor": "transparent",
+            "color": "#597183",
           },
           "uranus": Object {
             "backgroundColor": "transparent",
@@ -2013,6 +2081,11 @@ exports[`InputMasked renders date masked input 1`] = `
               "borderColor": "transparent",
               "color": "#d45459",
             },
+            "moon": Object {
+              "backgroundColor": "transparent",
+              "borderColor": "transparent",
+              "color": "#597183",
+            },
             "uranus": Object {
               "backgroundColor": "transparent",
               "borderColor": "transparent",
@@ -2217,6 +2290,8 @@ exports[`InputMasked renders date masked input 1`] = `
     <InputMasked
       className=""
       decimalScale={2}
+      decimalSeparator=","
+      displayValidationIcon={true}
       inputId="inputId"
       inputSize="medium"
       isInvalid={false}
@@ -2233,6 +2308,7 @@ exports[`InputMasked renders date masked input 1`] = `
         }
       }
       noAnimate={true}
+      thousandSeparator="."
     >
       <InputMask
         alwaysShowMask={false}
@@ -2247,6 +2323,7 @@ exports[`InputMasked renders date masked input 1`] = `
         >
           <InputText
             className=""
+            displayValidationIcon={true}
             inputId="inputId"
             inputSize="medium"
             isInvalid={false}
@@ -2340,7 +2417,11 @@ exports[`InputMasked renders date masked input 1`] = `
                               [Function],
                               ";}",
                               [Function],
-                              ";}& + label{left:0;position:absolute;top:0;transition:transform 0.25s,opacity 0.25s ease-in-out;transform-origin:0 0;}",
+                              ";}&.--no-animate{",
+                              [Function],
+                              ";&:focus{",
+                              [Function],
+                              ";}}& + label{left:0;position:absolute;top:0;transition:transform 0.25s,opacity 0.25s ease-in-out;transform-origin:0 0;}",
                             ],
                           },
                           "displayName": "InputText__InputField",

--- a/packages/components/src/InputMasked/index.js
+++ b/packages/components/src/InputMasked/index.js
@@ -20,45 +20,29 @@ export const maskTypes = {
 };
 
 const InputMasked = ({
-  inputId,
-  labelId,
-  labelText,
-  isValidated,
-  isInvalid,
-  errorMessage,
-  labelProps,
-  noAnimate,
-  placeholder,
   mask,
   maskType,
   maskPlaceholder,
+  thousandSeparator,
+  decimalSeparator,
   decimalScale,
-  rest,
+  ...inputProps
 }) => {
-  const commonProps = {
-    inputId,
-    labelId,
-    labelText,
-    isValidated,
-    isInvalid,
-    errorMessage,
-    labelProps,
-    rest,
-    noAnimate,
-  };
-
   return maskType === maskTypes.currency ? (
     <NumberFormat
-      {...commonProps}
+      {...inputProps}
       customInput={InputText}
-      placeholder={maskType.placeholder}
-      thousandSeparator="."
-      decimalSeparator=","
+      placeholder={inputProps.placeholder ? inputProps.placeholder : maskType.placeholder}
+      thousandSeparator={thousandSeparator}
+      decimalSeparator={decimalSeparator}
       decimalScale={decimalScale}
     />
   ) : (
     <InputMask mask={maskType ? maskType.mask : mask} maskPlaceholder={maskPlaceholder}>
-      <InputText {...commonProps} placeholder={maskType ? maskType.placeholder : placeholder} />
+      <InputText
+        {...inputProps}
+        placeholder={inputProps.placeholder ? inputProps.placeholder : maskType.placeholder}
+      />
     </InputMask>
   );
 };
@@ -66,19 +50,23 @@ const InputMasked = ({
 InputMasked.displayName = 'InputMasked';
 
 InputMasked.defaultProps = {
-  ...InputText.defaultProps,
-  noAnimate: true,
   mask: '',
   maskPlaceholder: '',
+  thousandSeparator: '.',
+  decimalSeparator: ',',
   decimalScale: 2,
+  ...InputText.defaultProps,
+  noAnimate: true,
 };
 
 InputMasked.propTypes = {
-  ...InputText.propTypes,
   mask: PropTypes.string,
   maskType: PropTypes.oneOf([maskTypes.cpf, maskTypes.currency, maskTypes.date]),
   maskPlaceholder: PropTypes.string,
+  thousandSeparator: PropTypes.string,
+  decimalSeparator: PropTypes.string,
   decimalScale: PropTypes.number,
+  ...InputText.propTypes,
 };
 
 export default InputMasked;

--- a/packages/components/src/InputText/__tests__/__snapshots__/index.js.snap
+++ b/packages/components/src/InputText/__tests__/__snapshots__/index.js.snap
@@ -93,6 +93,14 @@ exports[`input text renders correctly the input without animation 1`] = `
   transform: translate(3px,-6px) scale(0.8);
 }
 
+.c1.--no-animate {
+  border-color: #597183;
+}
+
+.c1.--no-animate:focus {
+  border-color: #159ce4;
+}
+
 .c1 + label {
   left: 0;
   position: absolute;
@@ -224,6 +232,16 @@ exports[`input text renders correctly the invalid input 1`] = `
   -webkit-transform: translate(3px,-6px) scale(0.8);
   -ms-transform: translate(3px,-6px) scale(0.8);
   transform: translate(3px,-6px) scale(0.8);
+}
+
+.c1.--no-animate {
+  border-color: #d45459;
+  padding-right: 48px;
+}
+
+.c1.--no-animate:focus {
+  border-color: #d45459;
+  padding-right: 48px;
 }
 
 .c1 + label {
@@ -403,6 +421,14 @@ exports[`input text renders correctly the large input and checks its font size 1
   transform: translate(8px,-3px) scale(0.6);
 }
 
+.c1.--no-animate {
+  border-color: #597183;
+}
+
+.c1.--no-animate:focus {
+  border-color: #159ce4;
+}
+
 .c1 + label {
   left: 0;
   position: absolute;
@@ -526,6 +552,14 @@ exports[`input text renders correctly the standard input 1`] = `
   -webkit-transform: translate(3px,-6px) scale(0.8);
   -ms-transform: translate(3px,-6px) scale(0.8);
   transform: translate(3px,-6px) scale(0.8);
+}
+
+.c1.--no-animate {
+  border-color: #597183;
+}
+
+.c1.--no-animate:focus {
+  border-color: #159ce4;
 }
 
 .c1 + label {
@@ -659,6 +693,16 @@ exports[`input text renders correctly the validated input 1`] = `
   -webkit-transform: translate(3px,-6px) scale(0.8);
   -ms-transform: translate(3px,-6px) scale(0.8);
   transform: translate(3px,-6px) scale(0.8);
+}
+
+.c1.--no-animate {
+  border-color: #74e24a;
+  padding-right: 48px;
+}
+
+.c1.--no-animate:focus {
+  border-color: #74e24a;
+  padding-right: 48px;
 }
 
 .c1 + label {

--- a/packages/components/src/InputText/index.js
+++ b/packages/components/src/InputText/index.js
@@ -137,6 +137,14 @@ const InputField = styled.input`
     ${props => inputValidationStyles({ ...props, defaultColor: props.theme.colors.uranus500 })};
   }
 
+  &.--no-animate {
+    ${props => inputValidationStyles({ ...props, defaultColor: props.theme.colors.moon500 })};
+
+    &:focus {
+      ${props => inputValidationStyles({ ...props, defaultColor: props.theme.colors.uranus500 })};
+    }
+  }
+
   & + label {
     left: 0;
     position: absolute;
@@ -170,6 +178,7 @@ const InputText = ({
   noAnimate,
   className,
   inputSize,
+  displayValidationIcon,
   ...rest
 }) => (
   <>
@@ -194,10 +203,12 @@ const InputText = ({
         {...labelProps}>
         {labelText}
       </InputLabel>
-      {isValidated && (
+      {isValidated && displayValidationIcon && (
         <IconCircleCheck color="earth400" size="32" style={{ ...iconStyles(inputSize) }} />
       )}
-      {isInvalid && <IconAlert color="mars500" size="32" style={{ ...iconStyles(inputSize) }} />}
+      {isInvalid && displayValidationIcon && (
+        <IconAlert color="mars500" size="32" style={{ ...iconStyles(inputSize) }} />
+      )}
       {isInvalid && errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
     </InputWrapper>
   </>
@@ -214,6 +225,7 @@ InputText.defaultProps = {
   labelProps: {},
   className: '',
   inputSize: inputSizes.medium,
+  displayValidationIcon: true,
 };
 
 InputText.propTypes = {
@@ -226,6 +238,7 @@ InputText.propTypes = {
   errorMessage: PropTypes.string,
   labelProps: PropTypes.object,
   inputSize: PropTypes.oneOf([inputSizes.medium, inputSizes.large]),
+  displayValidationIcon: PropTypes.bool,
 };
 
 export default InputText;

--- a/packages/core/src/themes/control.js
+++ b/packages/core/src/themes/control.js
@@ -93,6 +93,11 @@ const theme = {
         color: baseTheme.colors.mars500,
         borderColor: 'transparent',
       },
+      moon: {
+        backgroundColor: 'transparent',
+        color: baseTheme.colors.moon500,
+        borderColor: 'transparent',
+      },
     },
   },
   buttonSizes: {


### PR DESCRIPTION
# What

This PR adds the Input control component to the Galaxy.

# Why

To allow users to increment or decrement numeric fields.

# How

* Add control input component, styles, markup, and test
* Perform minor optimizations in other components to support control input requisites 

_As other Galaxy components, this component has no state logic inside it (dumb type). I put a sample state usage in the storybook demo in order to the component to work._

# Samples

<img width="208" alt="Captura de Tela 2020-04-03 às 16 55 20" src="https://user-images.githubusercontent.com/1002072/78399961-433beb80-75cc-11ea-825b-0120aa6da035.png">

<img width="1057" alt="Captura de Tela 2020-04-03 às 16 55 37" src="https://user-images.githubusercontent.com/1002072/78399978-48993600-75cc-11ea-969a-8783ba66bf8f.png">

<img width="1059" alt="Captura de Tela 2020-04-03 às 16 56 06" src="https://user-images.githubusercontent.com/1002072/78399991-4e8f1700-75cc-11ea-86a4-e0851d496e4c.png">

<img width="1059" alt="Captura de Tela 2020-04-03 às 16 57 30" src="https://user-images.githubusercontent.com/1002072/78400035-5d75c980-75cc-11ea-91c7-65afa924246e.png">

<img width="1060" alt="Captura de Tela 2020-04-03 às 16 56 32" src="https://user-images.githubusercontent.com/1002072/78400059-636baa80-75cc-11ea-961e-8b452eaddc8a.png">

<img width="1057" alt="Captura de Tela 2020-04-03 às 16 57 10" src="https://user-images.githubusercontent.com/1002072/78400071-6a92b880-75cc-11ea-8287-636a27ed8b55.png">

# Refs

* [Clubhouse card](https://app.clubhouse.io/magnetis/story/23902/criar-input-com-controles-no-galaxy)