### PR TITLE
Add icons page

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
     alias: {
       '@magnetis/astro-galaxy-core': path.resolve(__dirname, '../packages/core/src'),
       '@magnetis/astro-galaxy-icons': path.resolve(__dirname, '../packages/icons/lib/index.es.js'),
+      '@magnetis/astro-galaxy-tokens': path.resolve(__dirname, '../packages/tokens/src'),
       '@magnetis/astro-galaxy-components': path.resolve(__dirname, '../packages/components/src'),
     },
   },

--- a/docs/04_Iconography.stories.mdx
+++ b/docs/04_Iconography.stories.mdx
@@ -1,4 +1,7 @@
 import { Meta, Preview, Story } from '@storybook/addon-docs/blocks';
+import { DashboardIcons, SupportIcons } from './components/IconsCollection';
+import { IconCalendar } from '@magnetis/astro-galaxy-icons';
+import { colors } from '@magnetis/astro-galaxy-tokens';
 
 <Meta title="/iconography" />
 
@@ -11,31 +14,60 @@ import { Meta, Preview, Story } from '@storybook/addon-docs/blocks';
 All icons have a 32x32px bound as default format. They can be resized in our 16px baseline as required.
 
 <Story name="dashboard icons">
-  <>dashboard icons.</>
+  <DashboardIcons />
 </Story>
 
 ## support icons
 
 <Story name="support icons">
-  <>support icons.</>
+  <SupportIcons />
 </Story>
 
 ## icons usage
 
 ### minimum
 
-<Story name="icons usage">
-  <>icons usage.</>
-</Story>
+To use an icon, import it (by one of the names above) from `@magnetis/astro-galaxy-icons` and use it as a React component.
+
+<Preview>
+  <Story name="icons usage">
+    <IconCalendar />
+  </Story>
+</Preview>
 
 ### sizes
 
+You can modify an icon's size by using the prop `size` with one of the following values: `24`, `32` or `40`.
+
 <Preview>
-  <>Icons sizes.</>
+  <>
+    <IconCalendar size="24" />
+    <IconCalendar size="32" />
+    <IconCalendar size="40" />
+  </>
+</Preview>
+
+### colors
+
+You can also modify the color with the prop `color`.
+
+<Preview>
+  <>
+    <IconCalendar color={colors.uranus500} size="40" />
+    <IconCalendar color={colors.mars400} size="40" />
+    <IconCalendar color={colors.earth300} size="40" />
+    <IconCalendar color={colors.venus200} size="40" />
+  </>
 </Preview>
 
 ### spacers
 
+You can apply spacing using the props `margin`, `marginLeft`, `marginRight`, `marginTop`, `marginBottom` or their shorthands; `m`, `ml`, `mr`, `mt`, `mb` respectively.
+
 <Preview>
-  <>Icons spacers.</>
+  <>
+    <IconCalendar margin={3} size="24" />
+    <IconCalendar margin={3} size="32" />
+    <IconCalendar margin={3} size="40" />
+  </>
 </Preview>

--- a/docs/components/IconsCollection.js
+++ b/docs/components/IconsCollection.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import styled from 'styled-components';
+import * as icons from '@magnetis/astro-galaxy-icons';
+
+const Collection = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  margin-left: -16px;
+`;
+
+const Item = styled.div`
+  margin: 16px;
+  text-align: center;
+  width: 72px;
+`;
+
+const Container = styled.div`
+  border: solid 1px ${props => props.theme.colors.moon300};
+  border-radius: 8px;
+  padding: 16px;
+`;
+
+const Name = styled.div`
+  font-family: 'Poppins', Arial, Helvetica, sans-serif;
+  font-size: 10px;
+  margin-top: 8px;
+`;
+
+const dashboardIcons = [
+  'IconAdditional',
+  'IconChart',
+  'IconInvite',
+  'IconTime',
+  'IconDown',
+  'IconSheet',
+  'IconChat',
+  'IconFlag',
+  'IconTransactions',
+  'IconHeart',
+];
+
+const excludedFromSupportIcons = [...dashboardIcons, 'IconInputDash', 'IconInputPlus'];
+
+const DashboardIcons = () => (
+  <Collection>
+    {dashboardIcons.map(icon => {
+      const Icon = icons[icon];
+      return (
+        <Item key={icon}>
+          <Container>
+            <Icon color="moon900" size="32" />
+          </Container>
+          <Name>{icon}</Name>
+        </Item>
+      );
+    })}
+  </Collection>
+);
+
+const SupportIcons = () => (
+  <Collection>
+    {Object.keys(icons)
+      .filter(icon => !excludedFromSupportIcons.includes(icon))
+      .map(icon => {
+        const Icon = icons[icon];
+        return (
+          <Item key={icon}>
+            <Container>
+              <Icon color="moon900" size="32" />
+            </Container>
+            <Name>{icon}</Name>
+          </Item>
+        );
+      })}
+  </Collection>
+);
+
+export { DashboardIcons, SupportIcons };


### PR DESCRIPTION
# What

This PR adds the complete icons page to the new Storybook docs.

It also adds support to `@magnetis/astro-galaxy-tokens` on Storybook.

# Why

For Astro Galaxy devs to have a reference of Input components usage.

# Sample

![The icons page, a lots of icons are presented](https://user-images.githubusercontent.com/1909761/79997004-779a1d80-848f-11ea-90a4-eac2425e8862.png)

