### PR TITLE
Add colors and gradients page

### DIFF
--- a/docs/02_Colors.stories.mdx
+++ b/docs/02_Colors.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta, Story } from '@storybook/addon-docs/blocks';
+import { ColorPalette, GradientCollection, GradientSwatch } from './components/ColorsCollection';
 
 <Meta title="/colors" />
 
@@ -12,10 +13,27 @@ Colors have their variations that may be used depending on the contextual need.
 
 ### usage
 
-Usage text.
+If your component lives inside `AstroThemeProvider`, you can access the colors via `theme` prop, for instance, instead of declaring a hexadecimal code like #fff, do this: `theme.colors.space100` (which is white, if you look in the Space palette below). If you need the darkest shade of green, for example, use `theme.colors.earth1000` and so forth.
+
+If you need to access the colors outside `AstroThemeProvider`, you might want to use it via `@magnetis/astro-galaxy-tokens`, to do so, make sure you install the package and then import the `colors` object: `import { colors } from '@magnetis/astro-galaxy-tokens'`.
 
 <Story name="tints">
-  <>tints colors swatches.</>
+  <>
+    <h3>earth</h3>
+    <ColorPalette family='earth' lightTextStart={500} />
+    <h3>venus</h3>
+    <ColorPalette family='venus' lightTextStart={400} />
+    <h3>uranus</h3>
+    <ColorPalette family='uranus' lightTextStart={400} />
+    <h3>moon</h3>
+    <ColorPalette family='moon' lightTextStart={400} />
+    <h3>mars</h3>
+    <ColorPalette family='mars' lightTextStart={400} />
+    <h3>sun</h3>
+    <ColorPalette family='sun' lightTextStart={600} />
+    <h3>space</h3>
+    <ColorPalette family='space' lightTextStart={500} />
+  </>
 </Story>
 
 ## gradients
@@ -24,8 +42,22 @@ Based on our brand guideline, they are normally used in main actions and macrost
 
 ### usage
 
-Usage text.
+You can access the colors via `theme` prop, for instance, instead of declaring a gradient code like linear-gradient(47.32deg, #d991e0 0%, #00c6d4 60.06%, #00ea60 100%), do this: `theme.gradients.nebulosa`. If you need the Andromeda gradient, for example, use `theme.gradients.andromeda` and so forth.
 
 <Story name="gradients">
-  <>gradient colors swatches.</>
+  <>
+    <GradientCollection>
+      <GradientSwatch gradient='nebulosa' />
+      <GradientSwatch gradient='andromeda' />
+      <GradientSwatch gradient='sombrero' />
+      <GradientSwatch gradient='milkyway' />
+      <GradientSwatch gradient='hoag' darkText />
+      <GradientSwatch gradient='centaurus' />
+      <GradientSwatch gradient='whirlpool' />
+      <GradientSwatch gradient='cartwheel' />
+      <GradientSwatch gradient='blackhole' />
+      <GradientSwatch gradient='mayall' />
+      <GradientSwatch gradient='pinwheel' />
+    </GradientCollection>
+  </>
 </Story>

--- a/docs/components/ColorsCollection.js
+++ b/docs/components/ColorsCollection.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import styled from 'styled-components';
+import { theme } from '@magnetis/astro-galaxy-core';
+
+const { colors, gradients } = theme;
+const tints = [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000];
+
+const getTextColor = (tint, lightTextStart) =>
+  tint < lightTextStart ? colors.moon1000 : colors.space100;
+
+const ColorPaletteSwatch = styled.div`
+  width: 72px;
+  height: 72px;
+  padding-top: 26px;
+  text-align: center;
+  font: ${props => props.theme.fonts.primary};
+
+  &:first-child {
+    border-top-left-radius: 8px;
+    border-bottom-left-radius: 8px;
+  }
+
+  &:last-child {
+    border-top-right-radius: 8px;
+    border-bottom-right-radius: 8px;
+  }
+`;
+
+const Palette = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 20px;
+  margin-bottom: 45px;
+`;
+
+const GradientCollectionWrapper = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, 128px);
+  grid-gap: 16px;
+  margin-top: 35px;
+`;
+
+const GradientCollectionSwatch = styled.div`
+  border-radius: 8px;
+  width: 128px;
+  height: 128px;
+  padding-top: 55px;
+  font: ${props => props.theme.fonts.primary};
+  text-align: center;
+`;
+
+const ColorSwatch = ({ family, tint, textColor }) => (
+  <ColorPaletteSwatch
+    style={{ backgroundColor: colors[`${family}${tint}`], color: textColor }}
+    data-color={colors[`${family}${tint}`]}>
+    <span>{tint}</span>
+  </ColorPaletteSwatch>
+);
+
+export const ColorPalette = ({ family, lightTextStart }) => (
+  <Palette>
+    {tints.map(tint => (
+      <ColorSwatch
+        key={`${family}${tint}`}
+        family={family}
+        tint={tint}
+        textColor={getTextColor(tint, lightTextStart)}
+      />
+    ))}
+  </Palette>
+);
+
+export const GradientSwatch = ({ gradient, darkText = false }) => (
+  <GradientCollectionSwatch
+    style={{
+      backgroundImage: gradients[gradient],
+      color: darkText ? colors.moon900 : colors.space100,
+    }}>
+    <span>{gradient}</span>
+  </GradientCollectionSwatch>
+);
+
+export const GradientCollection = ({ children }) => (
+  <GradientCollectionWrapper>{children}</GradientCollectionWrapper>
+);


### PR DESCRIPTION
# What

This PR adds the complete colors and gradients page to the new Storybook docs.

# Why

For Astro Galaxy devs to have a reference of Input components usage.

# Easter Egg

<img width="1579" alt="" src="https://user-images.githubusercontent.com/1909761/80020149-f2befc00-84ae-11ea-8d74-a7f11b2b9a45.png">


# Sample

![Astro Colors and gradients page](https://user-images.githubusercontent.com/1909761/80020086-d9b64b00-84ae-11ea-9977-588753acdc5c.png)

