### PR TITLE
Fix small screens layout issues

### DIFF
--- a/docs/.storybook/babel.config.js
+++ b/docs/.storybook/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  plugins: ['lodash'],
+  ignore: ['node_modules/**'],
+};

--- a/docs/.storybook/preview-head.html
+++ b/docs/.storybook/preview-head.html
@@ -5,7 +5,7 @@
     color: var(--color-moon-900) !important;
     font: var(--font-secondary) !important;
     font-size: var(--font-size-2base) !important;
-    padding: 40px !important;
+    padding: 8px !important;
   }
 
   h1.sbdocs-h1,
@@ -21,8 +21,9 @@
     border: 0 !important;
     color: var(--color-space-100) !important;
     font-size: var(--font-size-6base) !important;
-    margin: -105px -60px 40px !important;
-    padding: 80px 60px !important;
+    line-height: 1em !important;
+    margin: -72px -28px 40px !important;
+    padding: 40px 24px !important;
   }
 
   h2.sbdocs-h2,
@@ -56,5 +57,20 @@
   p.sbdocs-p {
     font: var(--font-secondary) !important;
     font-size: var(--font-size-2base) !important;
+  }
+
+  p.sbdocs-p code {
+    white-space: normal !important;
+  }
+
+  @media (min-width: 768px) {
+    body {
+      padding: 40px !important;
+    }
+
+    h1.sbdocs-h1 {
+      margin: -105px -60px 40px !important;
+      padding: 80px 60px !important;
+    }
   }
 </style>

--- a/docs/.storybook/preview.js
+++ b/docs/.storybook/preview.js
@@ -4,10 +4,16 @@ import React from 'react';
 import styled from 'styled-components';
 
 const StoryContainer = styled.div`
-  padding: 0 ${props => props.theme.space[2]}px;
-
   > * {
-    margin: ${props => props.theme.space[1]}px;
+    margin: ${props => props.theme.space[1] / 2}px;
+  }
+
+  @media (min-width: 768px) {
+    padding: 0 ${props => props.theme.space[2]}px;
+
+    > * {
+      margin: ${props => props.theme.space[1]}px;
+    }
   }
 `;
 

--- a/docs/.storybook/webpack.config.js
+++ b/docs/.storybook/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const maxAssetSize = 1024 * 1024;
 
 module.exports = {
   devtool: 'source-map',
@@ -37,5 +38,15 @@ module.exports = {
       '@magnetis/astro-galaxy-tokens': path.resolve(__dirname, '../../packages/tokens/src'),
       '@magnetis/astro-galaxy-components': path.resolve(__dirname, '../../packages/components/src'),
     },
+  },
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+      minSize: 30 * 1024,
+      maxSize: maxAssetSize,
+    },
+  },
+  performance: {
+    maxAssetSize: maxAssetSize,
   },
 };

--- a/docs/src/07_ControlsAndToggles.stories.mdx
+++ b/docs/src/07_ControlsAndToggles.stories.mdx
@@ -97,7 +97,7 @@ To create the disabled state, add the disabled attribute on the `Checkbox` compo
         <Label htmlFor="checkbox2">Checked</Label>
       </CheckboxWrapper>
       <CheckboxWrapper>
-        <Checkbox indeterminate id="checkbox3" checked />
+        <Checkbox indeterminate id="checkbox3" defaultChecked />
         <CheckboxShape />
         <Label htmlFor="checkbox3">Checkbox</Label>
       </CheckboxWrapper>
@@ -157,6 +157,7 @@ To set the disabled state, add the `disabled` attribute.
       return (
         <>
           <Slider
+            id="slider"
             label="Wallet"
             counterLabel={counterLabel}
             value={value}

--- a/docs/src/08_Tables.stories.mdx
+++ b/docs/src/08_Tables.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Preview, Story } from '@storybook/addon-docs/blocks';
 import { IconGhostButton } from '@magnetis/astro-galaxy-components';
+import { IconPencil, IconTrash } from '@magnetis/astro-galaxy-icons';
 import Table from '@magnetis/astro-galaxy-components/Table';
 
 <Meta title="/tables" />

--- a/docs/src/components/Card.js
+++ b/docs/src/components/Card.js
@@ -36,7 +36,7 @@ export const CardCode = styled.code`
 `;
 
 export const Card = styled.div`
-  padding-bottom: 60px;
+  padding-bottom: 72px;
   position: relative;
   width: 100%;
 `;

--- a/docs/src/components/PreviewGrid.js
+++ b/docs/src/components/PreviewGrid.js
@@ -1,10 +1,20 @@
 import styled from 'styled-components';
 
 const PreviewGrid = styled.div`
-  display: grid;
-  grid-gap: ${props => props.theme.space[3]}px;
-  grid-template-columns: repeat(${props => props.columns}, 1fr);
-  margin: 0 -${props => props.theme.space[2]}px;
+  & > * {
+    margin-top: ${props => props.theme.space[5]}px;
+  }
+
+  @media (min-width: 768px) {
+    display: grid;
+    grid-gap: ${props => props.theme.space[3]}px;
+    grid-template-columns: repeat(${props => props.columns}, 1fr);
+    margin: 0 -${props => props.theme.space[2]}px;
+
+    & > * {
+      margin-top: 0;
+    }
+  }
 `;
 
 export default PreviewGrid;

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel-eslint": "9.x",
     "babel-jest": "^24.8.0",
     "babel-loader": "^8.0.6",
+    "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-styled-components": "^1.10.5",
     "babel-preset-es2015-rollup": "^3.0.0",
     "enzyme": "^3.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -398,7 +398,7 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
-"@babel/helper-module-imports@^7.8.3":
+"@babel/helper-module-imports@^7.0.0-beta.49", "@babel/helper-module-imports@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz#7fe39589b39c016331b6b8c3f441e8f0b1419498"
   integrity sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
@@ -1787,6 +1787,15 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.0.0-beta.49", "@babel/types@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.5.tgz#89231f82915a8a566a703b3b20133f73da6b9444"
+  integrity sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.5"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
 "@babel/types@^7.6.0", "@babel/types@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.7.4.tgz#516570d539e44ddf308c07569c258ff94fde9193"
@@ -1802,15 +1811,6 @@
   integrity sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==
   dependencies:
     "@babel/helper-validator-identifier" "^7.9.0"
-    lodash "^4.17.13"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.9.5":
-  version "7.9.5"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.5.tgz#89231f82915a8a566a703b3b20133f73da6b9444"
-  integrity sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.9.5"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
@@ -5091,6 +5091,17 @@ babel-plugin-jest-hoist@^24.6.0:
   integrity sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==
   dependencies:
     "@types/babel__traverse" "^7.0.6"
+
+babel-plugin-lodash@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz#4f6844358a1340baed182adbeffa8df9967bc196"
+  integrity sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0-beta.49"
+    "@babel/types" "^7.0.0-beta.49"
+    glob "^7.1.1"
+    lodash "^4.17.10"
+    require-package-name "^2.0.1"
 
 babel-plugin-macros@^2.0.0:
   version "2.6.1"
@@ -14930,6 +14941,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+require-package-name@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
+  integrity sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=
 
 require-relative@^0.8.7:
   version "0.8.7"


### PR DESCRIPTION
# What

This PR makes some style adjustments to address some layout bugs in small screen resolutions.

# Why

So that Astro users can consult the documentation on smaller screens.

# How

* Adjusts paddings and margins on some elements
* Handles the alignment of the `<PreviewGrid>` component items on small screens
* Fixes H1 spacing on small screens
 
This PR also:

* Fixes some props and imports to eliminate console error messages
* Tries to improve the build and size of the bundle with a babel `lodash` plugin and some Webpack parameters

# Samples

| | | |
| --- | --- | --- |
| <img width="361" alt="Captura de Tela 2020-04-27 às 14 13 39" src="https://user-images.githubusercontent.com/1002072/80401689-25903800-8893-11ea-8861-daf975e24508.png"> | <img width="358" alt="Captura de Tela 2020-04-27 às 14 14 02" src="https://user-images.githubusercontent.com/1002072/80401707-2e810980-8893-11ea-9ad0-d106ab2f83e8.png"> | <img width="359" alt="Captura de Tela 2020-04-27 às 14 14 33" src="https://user-images.githubusercontent.com/1002072/80401714-32149080-8893-11ea-893a-e3a7ff86dfc1.png"> |

# Refs

* [Clubhouse card](https://app.clubhouse.io/magnetis/story/36105/ajustar-storybook-em-resoluções-mobile) [ch36105]