### PR TITLE
Fix page titles

### DIFF
--- a/docs/.storybook/manager-head.html
+++ b/docs/.storybook/manager-head.html
@@ -1,8 +1,8 @@
-<meta name="description" content="Astro Galaxy - Magnetis' Design System">
-<link rel="icon" type="image/x-icon" href="/favicon.png">
-<link rel="dns-prefetch" href="https://unpkg.com">
-<link rel="dns-prefetch" href="https://fonts.gstatic.com">
-<link rel="stylesheet" href="https://unpkg.com/@magnetis/astro/dist/astro.css">
+<meta name="description" content="Astro Galaxy - Magnetis' Design System" />
+<link rel="icon" type="image/x-icon" href="/favicon.png" />
+<link rel="dns-prefetch" href="https://unpkg.com" />
+<link rel="dns-prefetch" href="https://fonts.gstatic.com" />
+<link rel="stylesheet" href="https://unpkg.com/@magnetis/astro/dist/astro.css" />
 
 <style>
   body {
@@ -12,22 +12,22 @@
   }
 
   /* root menu */
-  .simplebar-content section > div > a {
+  .simplebar-content section > a {
     border-top: 1px solid var(--color-moon-200) !important;
-    padding: 16px 0 !important;
+    padding: 16px 8px !important;
   }
 
-  .simplebar-content section > div > a span {
+  .simplebar-content section > a span {
     color: var(--color-moon-900);
   }
 
   /* root menu arrow */
-  .simplebar-content section > div > a > div > span.sidebar-expander {
+  .simplebar-content section > a > div > span.sidebar-expander {
     border-left: 3.5px solid var(--color-moon-900);
   }
 
   /* child menu */
-  .simplebar-content section > div > div > a {
+  .simplebar-content section > div > a {
     margin-bottom: 16px !important;
     margin-top: -8px !important;
   }

--- a/docs/src/01_Home.stories.mdx
+++ b/docs/src/01_Home.stories.mdx
@@ -15,7 +15,7 @@ import AtomicIllustration from '../assets/illustrations/atomic.png';
 import OpenIllustration from '../assets/illustrations/open.png';
 import AccessibleIllustration from '../assets/illustrations/accessible.png';
 
-<Meta title="/home" />
+<Meta title="home" />
 
 # introduction
 

--- a/docs/src/02_Colors.stories.mdx
+++ b/docs/src/02_Colors.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story } from '@storybook/addon-docs/blocks';
 import { ColorPalette, GradientCollection, GradientSwatch } from './components/ColorsCollection';
 
-<Meta title="/colors" />
+<Meta title="colors" />
 
 # colors
 
@@ -20,19 +20,19 @@ If you need to access the colors outside `AstroThemeProvider`, you might want to
 <Story name="tints">
   <>
     <h3>earth</h3>
-    <ColorPalette family='earth' lightTextStart={500} />
+    <ColorPalette family="earth" lightTextStart={500} />
     <h3>venus</h3>
-    <ColorPalette family='venus' lightTextStart={400} />
+    <ColorPalette family="venus" lightTextStart={400} />
     <h3>uranus</h3>
-    <ColorPalette family='uranus' lightTextStart={400} />
+    <ColorPalette family="uranus" lightTextStart={400} />
     <h3>moon</h3>
-    <ColorPalette family='moon' lightTextStart={400} />
+    <ColorPalette family="moon" lightTextStart={400} />
     <h3>mars</h3>
-    <ColorPalette family='mars' lightTextStart={400} />
+    <ColorPalette family="mars" lightTextStart={400} />
     <h3>sun</h3>
-    <ColorPalette family='sun' lightTextStart={600} />
+    <ColorPalette family="sun" lightTextStart={600} />
     <h3>space</h3>
-    <ColorPalette family='space' lightTextStart={500} />
+    <ColorPalette family="space" lightTextStart={500} />
   </>
 </Story>
 
@@ -47,17 +47,17 @@ You can access the colors via `theme` prop, for instance, instead of declaring a
 <Story name="gradients">
   <>
     <GradientCollection>
-      <GradientSwatch gradient='nebulosa' />
-      <GradientSwatch gradient='andromeda' />
-      <GradientSwatch gradient='sombrero' />
-      <GradientSwatch gradient='milkyway' />
-      <GradientSwatch gradient='hoag' darkText />
-      <GradientSwatch gradient='centaurus' />
-      <GradientSwatch gradient='whirlpool' />
-      <GradientSwatch gradient='cartwheel' />
-      <GradientSwatch gradient='blackhole' />
-      <GradientSwatch gradient='mayall' />
-      <GradientSwatch gradient='pinwheel' />
+      <GradientSwatch gradient="nebulosa" />
+      <GradientSwatch gradient="andromeda" />
+      <GradientSwatch gradient="sombrero" />
+      <GradientSwatch gradient="milkyway" />
+      <GradientSwatch gradient="hoag" darkText />
+      <GradientSwatch gradient="centaurus" />
+      <GradientSwatch gradient="whirlpool" />
+      <GradientSwatch gradient="cartwheel" />
+      <GradientSwatch gradient="blackhole" />
+      <GradientSwatch gradient="mayall" />
+      <GradientSwatch gradient="pinwheel" />
     </GradientCollection>
   </>
 </Story>

--- a/docs/src/03_Typography.stories.mdx
+++ b/docs/src/03_Typography.stories.mdx
@@ -2,7 +2,7 @@ import { Meta, Preview, Story } from '@storybook/addon-docs/blocks';
 import { Heading, Text } from '@magnetis/astro-galaxy-components';
 import PreviewDivider from './components/PreviewDivider';
 
-<Meta title="/typography" />
+<Meta title="typography" />
 
 # typography
 

--- a/docs/src/04_Iconography.stories.mdx
+++ b/docs/src/04_Iconography.stories.mdx
@@ -3,7 +3,7 @@ import { DashboardIcons, SupportIcons } from './components/IconsCollection';
 import { IconCalendar } from '@magnetis/astro-galaxy-icons';
 import { colors } from '@magnetis/astro-galaxy-tokens';
 
-<Meta title="/iconography" />
+<Meta title="iconography" />
 
 # iconography
 

--- a/docs/src/05_Buttons.stories.mdx
+++ b/docs/src/05_Buttons.stories.mdx
@@ -12,7 +12,7 @@ import { theme } from '@magnetis/astro-galaxy-core';
 import { IconCalendar } from '@magnetis/astro-galaxy-icons';
 import PreviewDivider from './components/PreviewDivider';
 
-<Meta title="/buttons" />
+<Meta title="buttons" />
 
 # buttons
 

--- a/docs/src/06_Inputs.stories.mdx
+++ b/docs/src/06_Inputs.stories.mdx
@@ -20,7 +20,7 @@ import {
 } from '@magnetis/astro-galaxy-components';
 import { PreviewDivider, PreviewGrid } from './components';
 
-<Meta title="/inputs" />
+<Meta title="inputs" />
 
 # inputs
 

--- a/docs/src/07_ControlsAndToggles.stories.mdx
+++ b/docs/src/07_ControlsAndToggles.stories.mdx
@@ -17,7 +17,7 @@ import { IconCalendar, IconClock, IconCup } from '@magnetis/astro-galaxy-icons';
 import Tabbed, { Section, Tab } from '@magnetis/astro-galaxy-components/Tabbed';
 import PreviewDivider from './components/PreviewDivider';
 
-<Meta title="/controls & toggles" />
+<Meta title="controls & toggles" />
 
 # controls & toggles
 

--- a/docs/src/08_Tables.stories.mdx
+++ b/docs/src/08_Tables.stories.mdx
@@ -2,7 +2,7 @@ import { Meta, Preview, Story } from '@storybook/addon-docs/blocks';
 import { IconGhostButton, Table } from '@magnetis/astro-galaxy-components';
 import { IconPencil, IconTrash } from '@magnetis/astro-galaxy-icons';
 
-<Meta title="/tables" />
+<Meta title="tables" />
 
 # tables
 


### PR DESCRIPTION
# What

This PR fixes the title of the pages, which were created with an additional backslash.

# Why

OCD. 😊 

# How

* Removes backslash from titles
* Adjusts styles to the changed menu structure

# Sample

<img width="394" alt="Captura de Tela 2020-04-30 às 11 19 36" src="https://user-images.githubusercontent.com/1002072/80721842-15679b00-8ad5-11ea-8744-57096c1d51b1.png">

# Refs

* [Clubhouse card](https://app.clubhouse.io/magnetis/story/36721/ajustar-títulos-das-páginas-no-storybook) [ch36721]