### PR TITLE
Fix Tabbed icons and doc icons

### DIFF
--- a/docs/src/components/IconsCollection.js
+++ b/docs/src/components/IconsCollection.js
@@ -15,6 +15,9 @@ const Item = styled.div`
 `;
 
 const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border: solid 1px ${props => props.theme.colors.moon300};
   border-radius: 8px;
   padding: 16px;

--- a/packages/components/src/Tabbed/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/components/src/Tabbed/__tests__/__snapshots__/index.test.js.snap
@@ -39,7 +39,7 @@ exports[`Tabbed should render correctly 1`] = `
 }
 
 .c2 svg {
-  fill: #32383c;
+  fill: #597183;
   margin-right: 4px;
 }
 
@@ -49,7 +49,7 @@ exports[`Tabbed should render correctly 1`] = `
 }
 
 .c2:hover svg {
-  fill: #c5c5c5;
+  fill: #afbec9;
 }
 
 .c4 {

--- a/packages/components/src/Tabbed/index.js
+++ b/packages/components/src/Tabbed/index.js
@@ -119,7 +119,7 @@ const TabItem = styled.a`
   text-decoration: none;
 
   svg {
-    fill: ${props => props.theme.colors.moon900};
+    fill: ${props => props.theme.colors.moon500};
     margin-right: 4px;
   }
 
@@ -128,7 +128,7 @@ const TabItem = styled.a`
     border-bottom: 2px solid ${props => props.theme.colors.moon200};
 
     svg {
-      fill: ${props => props.theme.colors.space400};
+      fill: ${props => props.theme.colors.moon300};
     }
   }
 `;


### PR DESCRIPTION
# What

This PR fix some issues reported during QA.

- Tabbed icons colors;
- Icons docs alignment;

# Sample

**Normal state should be `moon500`.**
<img width="935" alt="Tabbed component icons colors." src="https://user-images.githubusercontent.com/1909761/81010115-25acac80-8e2c-11ea-8901-c00e18cb03ee.png">

**Hover should be `moon300`.**
<img width="951" alt="Tabbed component icons colors on hover." src="https://user-images.githubusercontent.com/1909761/81010124-26ddd980-8e2c-11ea-9632-abaf157b185a.png">

**Icons docs alignments.**
<img width="1012" alt="Icons docs." src="https://user-images.githubusercontent.com/1909761/81010131-29403380-8e2c-11ea-95d4-64a252b5446f.png">

