### PR TITLE
Add galaxy-tokens dependency to galaxy-themes

### DIFF
--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -11,6 +11,7 @@
     "lib"
   ],
   "dependencies": {
+    "@magnetis/astro-galaxy-tokens": "^1.0.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "styled-components": "^4.4.1",


### PR DESCRIPTION
# What

This PR adds `@magnetis/astro-galaxy-tokens` as a dependency for `@magnetis/astro-galaxy-themes` package.

