### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### [1.1.1] - 2020-05-15
+
+- Correct Tabbed component export.
+- Change the Text component to display the secondary font as default.
+- Add more values for spacing on web theme (margin, padding, etc.).
+
 ### [1.1.0] - 2020-05-08
 
 - Add new icons; airplane, car, education.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magnetis/astro-galaxy-components",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
   "scripts": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magnetis/astro-galaxy-icons",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
   "files": [

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magnetis/astro-galaxy-themes",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
   "scripts": {
@@ -11,7 +11,7 @@
     "lib"
   ],
   "dependencies": {
-    "@magnetis/astro-galaxy-tokens": "^1.1.0",
+    "@magnetis/astro-galaxy-tokens": "^1.1.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "styled-components": "^4.4.1",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magnetis/astro-galaxy-tokens",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "lib/index.cjs.js",
   "module": "lib/index.es.js",
   "scripts": {


### PR DESCRIPTION
- Correct Tabbed component export.
- Change the Text component to display the secondary font as default.
- Add more values for spacing on web theme (margin, padding, etc.).