### PR TITLE
Add extra params to the Tabbed's Tab

### DIFF
--- a/packages/components/src/Tabbed/index.js
+++ b/packages/components/src/Tabbed/index.js
@@ -135,9 +135,9 @@ const TabItem = styled.a`
 
 export const Section = styled.section``;
 
-export const Tab = ({ id, children, selected }) => (
+export const Tab = ({ id, children, selected, ...rest }) => (
   <TabContainer>
-    <TabItem href={`#${id}`} aria-selected={selected}>
+    <TabItem href={`#${id}`} aria-selected={selected} {...rest}>
       {children}
     </TabItem>
   </TabContainer>


### PR DESCRIPTION
# What

This huge PR 😊 adds additional parameters to the `<Tab>` item of the `<Tabbed>` component.

# Why

This was necessary to, for example, add `onClick` handlers for analytics tracking.

# How

I'll let you guess. 😆 

# Sample

No visual perk this time.
